### PR TITLE
Fix search listing defaults and add safeCall wrapper

### DIFF
--- a/app/src/main/java/com/techmarketplace/repo/ListingsRepository.kt
+++ b/app/src/main/java/com/techmarketplace/repo/ListingsRepository.kt
@@ -74,8 +74,6 @@ class ListingsRepository(
             pageSize = pageSize,
             mine = mine,
             sellerId = sellerId
-        page: Int = 1,
-        pageSize: Int = 50
         )
     }
     suspend fun getListingDetail(id: String): ListingDetailDto =
@@ -120,4 +118,11 @@ class ListingsRepository(
         )
         return api.createListing(body)
     }
+
+    private suspend fun <T> safeCall(block: suspend () -> T): Result<T> =
+        try {
+            Result.success(block())
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
 }


### PR DESCRIPTION
## Summary
- remove the leftover page defaults from the searchListings request
- add a local safeCall helper so repository calls no longer reference an undefined symbol

## Testing
- bash ./gradlew :app:assembleDebug --console=plain *(fails: SDK location not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f55cff24a48324be621f55b547a287