### PR TITLE
Fix listing DTO models and profile wiring

### DIFF
--- a/app/src/main/java/com/techmarketplace/net/dto/ListingDtos.kt
+++ b/app/src/main/java/com/techmarketplace/net/dto/ListingDtos.kt
@@ -4,12 +4,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 // =======================
-// Catálogos
-// =======================
-
-// =======================
 // Listing: modelos de lectura (listado + detalle)
 // =======================
+
 @Serializable
 data class ListingSummaryDto(
     @SerialName("id") val id: String,
@@ -20,16 +17,7 @@ data class ListingSummaryDto(
     @SerialName("brand_id") val brandId: String? = null,
     @SerialName("price_cents") val priceCents: Int,
     @SerialName("currency") val currency: String = "COP",
-    @SerialName("category_id") val categoryId: String? = null,
-    @SerialName("brand_id") val brandId: String? = null,
-    @SerialName("photos") val photos: List<ListingPhotoDto> = emptyList(),
-
-    // NEW (present in your /listings payloads and needed for Profile)
-    @SerialName("seller_id") val sellerId: String? = null,
-    @SerialName("is_active") val isActive: Boolean = true,
-    @SerialName("created_at") val createdAt: String? = null,
-    @SerialName("updated_at") val updatedAt: String? = null
-    @SerialName("condition") val condition: String,
+    @SerialName("condition") val condition: String? = null,
     @SerialName("quantity") val quantity: Int = 1,
     @SerialName("is_active") val isActive: Boolean = true,
     @SerialName("latitude") val latitude: Double? = null,
@@ -45,19 +33,19 @@ data class ListingSummaryDto(
 data class ListingDetailDto(
     @SerialName("id") val id: String,
     @SerialName("seller_id") val sellerId: String? = null,
-    @SerialName("title") val title: String,
+    @SerialName("title") val title: String? = null,
     @SerialName("description") val description: String? = null,
-    @SerialName("category_id") val categoryId: String,
+    @SerialName("category_id") val categoryId: String = "",
     @SerialName("brand_id") val brandId: String? = null,
-    @SerialName("price_cents") val priceCents: Int,
-    @SerialName("currency") val currency: String = "COP",
-    @SerialName("condition") val condition: String,
-    @SerialName("quantity") val quantity: Int = 1,
-    @SerialName("is_active") val isActive: Boolean = true,
+    @SerialName("price_cents") val priceCents: Int? = null,
+    @SerialName("currency") val currency: String? = null,
+    @SerialName("condition") val condition: String? = null,
+    @SerialName("quantity") val quantity: Int? = null,
+    @SerialName("is_active") val isActive: Boolean? = null,
     @SerialName("latitude") val latitude: Double? = null,
     @SerialName("longitude") val longitude: Double? = null,
-    @SerialName("price_suggestion_used") val priceSuggestionUsed: Boolean = false,
-    @SerialName("quick_view_enabled") val quickViewEnabled: Boolean = true,
+    @SerialName("price_suggestion_used") val priceSuggestionUsed: Boolean? = null,
+    @SerialName("quick_view_enabled") val quickViewEnabled: Boolean? = null,
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("updated_at") val updatedAt: String? = null,
     @SerialName("photos") val photos: List<ListingPhotoDto> = emptyList()
@@ -83,7 +71,3 @@ data class SearchListingsResponse(
     @SerialName("page_size") val pageSize: Int,
     @SerialName("has_next") val hasNext: Boolean
 )
-
-
-
-

--- a/app/src/main/java/com/techmarketplace/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/techmarketplace/ui/profile/ProfileViewModel.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.techmarketplace.net.ApiClient
 import com.techmarketplace.net.dto.ListingSummaryDto
 import com.techmarketplace.net.dto.UserMe
 import com.techmarketplace.repo.AuthRepository
 import com.techmarketplace.repo.ListingsRepository
+import com.techmarketplace.storage.LocationStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,10 +30,10 @@ data class ProfileUiState(
     val hasNext: Boolean = false
 )
 
-class ProfileViewModel(private val app: Application) : ViewModel() {
-
-    private val authRepo by lazy { AuthRepository(app) }
-    private val listingsRepo by lazy { ListingsRepository(app) }
+class ProfileViewModel(
+    private val authRepo: AuthRepository,
+    private val listingsRepo: ListingsRepository
+) : ViewModel() {
 
     private val _ui = MutableStateFlow(ProfileUiState(loading = true))
     val ui: StateFlow<ProfileUiState> = _ui.asStateFlow()
@@ -113,7 +115,12 @@ class ProfileViewModel(private val app: Application) : ViewModel() {
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                    return ProfileViewModel(app) as T
+                    val authRepository = AuthRepository(app)
+                    val listingsRepository = ListingsRepository(
+                        api = ApiClient.listingApi(),
+                        locationStore = LocationStore(app)
+                    )
+                    return ProfileViewModel(authRepository, listingsRepository) as T
                 }
             }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ retrofit = "2.11.0"
 okhttp = "4.12.0"
 kotlinx-serialization = "1.7.3"
 datastore = "1.1.1"
-retrofit-ks-converter = "1.0.0"
 coroutines = "1.8.1"
 coil = "2.6.0"
 lifecycle = "2.8.6"
@@ -46,7 +45,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-retrofit-kotlinx-serialization = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit-ks-converter" }
+retrofit-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary
- clean up the listing DTO definitions to remove duplicate annotations and align optional fields
- inject real repositories into `ProfileViewModel` using `ApiClient` and `LocationStore`
- switch Retrofit to the official Kotlin serialization converter artifact

## Testing
- `./gradlew app:compileDebugKotlin --console=plain` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f5833806ec8324a994101ae635a28a