### PR TITLE
Add listing image upload flow

### DIFF
--- a/app/src/main/java/com/techmarketplace/net/ApiClient.kt
+++ b/app/src/main/java/com/techmarketplace/net/ApiClient.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.techmarketplace.BuildConfig
 import com.techmarketplace.net.api.AuthApi
+import com.techmarketplace.net.api.ImagesApi
 import com.techmarketplace.net.api.ListingApi
 import com.techmarketplace.net.api.OrdersApi
 import com.techmarketplace.net.api.PaymentsApi
@@ -47,6 +48,7 @@ object ApiClient {
     fun ordersApi(): OrdersApi = retrofit.create()
     fun paymentsApi(): PaymentsApi = retrofit.create()
     fun priceSuggestionsApi(): PriceSuggestionsApi = retrofit.create()
+    fun imagesApi(): ImagesApi = retrofit.create()
 
     /** Call once from Application or Activity: ApiClient.init(applicationContext) */
     fun init(appContext: Context) {

--- a/app/src/main/java/com/techmarketplace/net/api/ImagesApi.kt
+++ b/app/src/main/java/com/techmarketplace/net/api/ImagesApi.kt
@@ -9,7 +9,7 @@ interface ImagesApi {
     suspend fun presign(@Body body: PresignImageIn): PresignImageOut
 
     @POST("images/confirm")
-    suspend fun confirm(@Body body: ConfirmImageIn)
+    suspend fun confirm(@Body body: ConfirmImageIn): ConfirmImageOut
 }
 
 @Serializable
@@ -29,4 +29,9 @@ data class PresignImageOut(
 data class ConfirmImageIn(
     val listing_id: String,
     val object_key: String
+)
+
+@Serializable
+data class ConfirmImageOut(
+    val preview_url: String
 )

--- a/app/src/main/java/com/techmarketplace/repo/ImagesRepository.kt
+++ b/app/src/main/java/com/techmarketplace/repo/ImagesRepository.kt
@@ -1,0 +1,92 @@
+package com.techmarketplace.repo
+
+import com.techmarketplace.net.api.ConfirmImageIn
+import com.techmarketplace.net.api.ImagesApi
+import com.techmarketplace.net.api.PresignImageIn
+import java.io.IOException
+import java.net.URI
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class ImagesRepository(
+    private val api: ImagesApi,
+    private val uploadClient: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(120, TimeUnit.SECONDS)
+        .build()
+) {
+
+    suspend fun uploadListingImage(
+        listingId: String,
+        filename: String,
+        contentType: String,
+        bytes: ByteArray
+    ): String {
+        val presigned = api.presign(
+            PresignImageIn(
+                listing_id = listingId,
+                filename = filename,
+                content_type = contentType
+            )
+        )
+
+        val uploadUrl = fixPresignedUrl(presigned.upload_url)
+        putToPresigned(uploadUrl, bytes, contentType)
+        val confirm = api.confirm(ConfirmImageIn(listingId, presigned.object_key))
+        return confirm.preview_url
+    }
+
+    private suspend fun putToPresigned(url: String, bytes: ByteArray, contentType: String) {
+        val mediaType = contentType.toMediaTypeOrNull() ?: "application/octet-stream".toMediaType()
+        val request = Request.Builder()
+            .url(url)
+            .put(bytes.toRequestBody(mediaType))
+            .build()
+
+        withContext(Dispatchers.IO) {
+            uploadClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Upload failed with HTTP ${'$'}{response.code}")
+                }
+            }
+        }
+    }
+
+    private fun fixPresignedUrl(original: String): String {
+        return try {
+            val uri = URI(original)
+            val host = uri.host?.lowercase()
+            if (host != null && host in INTERNAL_MINIO_HOSTS) {
+                URI(
+                    uri.scheme,
+                    uri.userInfo,
+                    "10.0.2.2",
+                    uri.port,
+                    uri.path,
+                    uri.query,
+                    uri.fragment
+                ).toString()
+            } else {
+                original
+            }
+        } catch (_: Exception) {
+            original
+        }
+    }
+
+    companion object {
+        private val INTERNAL_MINIO_HOSTS = setOf(
+            "minio",
+            "minio.local",
+            "minio-svc",
+            "minio.default.svc.cluster.local"
+        )
+    }
+}

--- a/app/src/main/java/com/techmarketplace/ui/listings/ListingsViewModel.kt
+++ b/app/src/main/java/com/techmarketplace/ui/listings/ListingsViewModel.kt
@@ -9,11 +9,13 @@ import com.techmarketplace.net.ApiClient
 import com.techmarketplace.net.dto.CatalogItemDto
 import com.techmarketplace.net.dto.SearchListingsResponse
 import com.techmarketplace.repo.ListingsRepository
+import com.techmarketplace.repo.ImagesRepository
 import com.techmarketplace.storage.LocationStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
+import kotlinx.coroutines.withContext
 
 data class CatalogsState(
     val categories: List<CatalogItemDto> = emptyList(),
@@ -22,7 +24,8 @@ data class CatalogsState(
 
 class ListingsViewModel(
     app: Application,
-    private val repo: ListingsRepository
+    private val repo: ListingsRepository,
+    private val imagesRepo: ImagesRepository
 ) : AndroidViewModel(app) {
 
     private val _catalogs = MutableStateFlow(CatalogsState())
@@ -40,7 +43,7 @@ class ListingsViewModel(
         }
     }
 
-    fun createListing(
+    suspend fun createListing(
         title: String,
         description: String,
         categoryId: String,
@@ -48,31 +51,32 @@ class ListingsViewModel(
         priceCents: Int,
         currency: String,
         condition: String,
-        quantity: Int,
-        onResult: (ok: Boolean, msg: String?) -> Unit
-    ) {
-        viewModelScope.launch {
-            try {
-                repo.createListing(
-                    title = title,
-                    description = description,
-                    categoryId = categoryId,
-                    brandId = brandId,
-                    priceCents = priceCents,
-                    currency = currency,
-                    condition = condition,
-                    quantity = quantity,
-                    // flags opcionales
-                    priceSuggestionUsed = false,
-                    quickViewEnabled = true
-                )
-                onResult(true, null)
-            } catch (e: HttpException) {
-                val body = e.response()?.errorBody()?.string()
-                onResult(false, "HTTP ${e.code()}${if (!body.isNullOrBlank()) " – $body" else ""}")
-            } catch (e: Exception) {
-                onResult(false, e.message ?: "Network error")
-            }
+        quantity: Int
+    ): Result<ListingDetailDto> = withContext(Dispatchers.IO) {
+        runCatching {
+            repo.createListing(
+                title = title,
+                description = description,
+                categoryId = categoryId,
+                brandId = brandId,
+                priceCents = priceCents,
+                currency = currency,
+                condition = condition,
+                quantity = quantity,
+                priceSuggestionUsed = false,
+                quickViewEnabled = true
+            )
+        }
+    }
+
+    suspend fun uploadListingImage(
+        listingId: String,
+        filename: String,
+        contentType: String,
+        bytes: ByteArray
+    ): Result<String> = withContext(Dispatchers.IO) {
+        runCatching {
+            imagesRepo.uploadListingImage(listingId, filename, contentType, bytes)
         }
     }
 
@@ -81,9 +85,11 @@ class ListingsViewModel(
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 val api = ApiClient.listingApi()
+                val imagesApi = ApiClient.imagesApi()
                 val store = LocationStore(app)  // <- aquí inyectamos la ubicación guardada
                 val repository = ListingsRepository(api, store)
-                return ListingsViewModel(app, repository) as T
+                val imagesRepository = ImagesRepository(imagesApi)
+                return ListingsViewModel(app, repository, imagesRepository) as T
             }
         }
     }


### PR DESCRIPTION
## Summary
- propagate listing creation result through the add product flow and upload the selected photo via a presigned URL
- add an ImagesRepository plus helpers to handle presign, upload, and confirm steps while exposing the API client
- extend ListingsViewModel to return the created listing, support image uploads, and wire the screen callbacks accordingly

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4be3f75083248fa1667affe9ce17