### PR TITLE
Add support for uploading listing photos via presigned URLs

### DIFF
--- a/app/src/main/java/com/techmarketplace/feature/home/AddProductScreen.kt
+++ b/app/src/main/java/com/techmarketplace/feature/home/AddProductScreen.kt
@@ -72,7 +72,7 @@ fun AddProductRoute(
         categories = catalogsState.categories,
         brands = catalogsState.brands,
         onCancel = onCancel,
-        onSave = { title, description, categoryId, brandId, priceText, condition, quantity ->
+        onSave = { title, description, categoryId, brandId, priceText, condition, quantity, imageUri ->
             val priceCents = ((priceText.toDoubleOrNull() ?: 0.0)).roundToInt()
 
             vm.createListing(
@@ -83,13 +83,14 @@ fun AddProductRoute(
                 priceCents = priceCents,
                 currency = "COP",
                 condition = condition,
-                quantity = quantity.toIntOrNull() ?: 1
-            ) { ok, err ->
+                quantity = quantity.toIntOrNull() ?: 1,
+                imageUri = imageUri
+            ) { ok, message ->
                 if (ok) {
-                    Toast.makeText(ctx, "Listing created!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(ctx, message ?: "Listing created!", Toast.LENGTH_SHORT).show()
                     onSaved()
                 } else {
-                    Toast.makeText(ctx, err ?: "Error creating listing", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(ctx, message ?: "Error creating listing", Toast.LENGTH_SHORT).show()
                 }
             }
         }
@@ -110,7 +111,8 @@ fun AddProductScreen(
         brandId: String,
         price: String,
         condition: String,
-        quantity: String
+        quantity: String,
+        imageUri: Uri?
     ) -> Unit
 ) {
     val ctx = LocalContext.current
@@ -165,7 +167,8 @@ fun AddProductScreen(
                                 selectedBrand,
                                 price.trim(),
                                 condition,
-                                quantity.trim()
+                                quantity.trim(),
+                                imageUri
                             )
                         },
                         enabled = canSave

--- a/app/src/main/java/com/techmarketplace/net/ApiClient.kt
+++ b/app/src/main/java/com/techmarketplace/net/ApiClient.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.techmarketplace.BuildConfig
 import com.techmarketplace.net.api.AuthApi
+import com.techmarketplace.net.api.ImagesApi
 import com.techmarketplace.net.api.ListingApi
 import com.techmarketplace.net.api.OrdersApi
 import com.techmarketplace.net.api.PaymentsApi
@@ -42,6 +43,7 @@ object ApiClient {
     }
 
     fun listingApi(): ListingApi = retrofit.create()
+    fun imagesApi(): ImagesApi = retrofit.create()
     fun authApi(): AuthApi = retrofit.create()
     fun telemetryApi(): TelemetryApi = retrofit.create()
     fun ordersApi(): OrdersApi = retrofit.create()

--- a/app/src/main/java/com/techmarketplace/net/api/ImagesApi.kt
+++ b/app/src/main/java/com/techmarketplace/net/api/ImagesApi.kt
@@ -1,5 +1,6 @@
 package com.techmarketplace.net.api
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -9,7 +10,7 @@ interface ImagesApi {
     suspend fun presign(@Body body: PresignImageIn): PresignImageOut
 
     @POST("images/confirm")
-    suspend fun confirm(@Body body: ConfirmImageIn)
+    suspend fun confirm(@Body body: ConfirmImageIn): ConfirmImageOut
 }
 
 @Serializable
@@ -29,4 +30,9 @@ data class PresignImageOut(
 data class ConfirmImageIn(
     val listing_id: String,
     val object_key: String
+)
+
+@Serializable
+data class ConfirmImageOut(
+    @SerialName("preview_url") val previewUrl: String
 )

--- a/app/src/main/java/com/techmarketplace/repo/ImagesRepository.kt
+++ b/app/src/main/java/com/techmarketplace/repo/ImagesRepository.kt
@@ -1,0 +1,85 @@
+package com.techmarketplace.repo
+
+import com.techmarketplace.net.api.ConfirmImageIn
+import com.techmarketplace.net.api.ImagesApi
+import com.techmarketplace.net.api.PresignImageIn
+import java.io.IOException
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+
+class ImagesRepository(
+    private val api: ImagesApi
+) {
+
+    private val plainClient: OkHttpClient = OkHttpClient.Builder()
+        .callTimeout(2, TimeUnit.MINUTES)
+        .build()
+
+    suspend fun uploadListingPhoto(
+        listingId: String,
+        filename: String,
+        contentType: String,
+        bytes: ByteArray
+    ): String {
+        val presign = api.presign(
+            PresignImageIn(
+                listing_id = listingId,
+                filename = filename,
+                content_type = contentType
+            )
+        )
+
+        val uploadUrl = fixPresignedUrl(presign.upload_url)
+
+        plainClient.newCall(
+            Request.Builder()
+                .url(uploadUrl)
+                .put(bytes.toRequestBody(contentType.toMediaType()))
+                .build()
+        ).execute().use { response ->
+            validateUploadResponse(response)
+        }
+
+        val confirm = api.confirm(
+            ConfirmImageIn(
+                listing_id = listingId,
+                object_key = presign.object_key
+            )
+        )
+
+        return confirm.previewUrl
+    }
+
+    private fun validateUploadResponse(response: Response) {
+        if (response.isSuccessful) return
+        throw IOException("Upload failed with HTTP ${response.code}")
+    }
+
+    private fun fixPresignedUrl(url: String): String {
+        val parsed = url.toHttpUrlOrNull() ?: return url
+        val host = parsed.host.lowercase(Locale.US)
+        val internalHosts = setOf(
+            "minio",
+            "minio.local",
+            "minio-svc",
+            "minio.default.svc.cluster.local"
+        )
+
+        if (internalHosts.contains(host)) {
+            // Backend firma usando el host interno de MinIO. Desde el emulador Android
+            // ese host no es accesible; 10.0.2.2 apunta al localhost de la máquina anfitriona.
+            return parsed.newBuilder()
+                .host("10.0.2.2")
+                .build()
+                .toString()
+        }
+
+        return url
+    }
+}

--- a/app/src/main/java/com/techmarketplace/ui/listings/ListingsViewModel.kt
+++ b/app/src/main/java/com/techmarketplace/ui/listings/ListingsViewModel.kt
@@ -1,6 +1,9 @@
 package com.techmarketplace.ui.listings
 
 import android.app.Application
+import android.content.ContentResolver
+import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -9,10 +12,16 @@ import com.techmarketplace.net.ApiClient
 import com.techmarketplace.net.dto.CatalogItemDto
 import com.techmarketplace.net.dto.SearchListingsResponse
 import com.techmarketplace.repo.ListingsRepository
+import com.techmarketplace.repo.ImagesRepository
 import com.techmarketplace.storage.LocationStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+import java.util.Locale
 import retrofit2.HttpException
 
 data class CatalogsState(
@@ -22,7 +31,8 @@ data class CatalogsState(
 
 class ListingsViewModel(
     app: Application,
-    private val repo: ListingsRepository
+    private val repo: ListingsRepository,
+    private val imagesRepo: ImagesRepository
 ) : AndroidViewModel(app) {
 
     private val _catalogs = MutableStateFlow(CatalogsState())
@@ -49,10 +59,18 @@ class ListingsViewModel(
         currency: String,
         condition: String,
         quantity: Int,
+        imageUri: Uri?,
         onResult: (ok: Boolean, msg: String?) -> Unit
     ) {
         viewModelScope.launch {
             try {
+                val imageData = try {
+                    imageUri?.let { resolveImageData(it) }
+                } catch (e: Exception) {
+                    onResult(false, e.message ?: "Could not read image data")
+                    return@launch
+                }
+
                 repo.createListing(
                     title = title,
                     description = description,
@@ -65,7 +83,22 @@ class ListingsViewModel(
                     // flags opcionales
                     priceSuggestionUsed = false,
                     quickViewEnabled = true
-                )
+                ).also { detail ->
+                    if (imageData != null) {
+                        try {
+                            imagesRepo.uploadListingPhoto(
+                                listingId = detail.id,
+                                filename = imageData.filename,
+                                contentType = imageData.contentType,
+                                bytes = imageData.bytes
+                            )
+                        } catch (uploadError: Exception) {
+                            val message = uploadError.message ?: "Failed to upload photo"
+                            onResult(true, "Listing created but photo upload failed: $message")
+                            return@launch
+                        }
+                    }
+                }
                 onResult(true, null)
             } catch (e: HttpException) {
                 val body = e.response()?.errorBody()?.string()
@@ -81,10 +114,68 @@ class ListingsViewModel(
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 val api = ApiClient.listingApi()
+                val imagesApi = ApiClient.imagesApi()
                 val store = LocationStore(app)  // <- aquí inyectamos la ubicación guardada
                 val repository = ListingsRepository(api, store)
-                return ListingsViewModel(app, repository) as T
+                val imagesRepository = ImagesRepository(imagesApi)
+                return ListingsViewModel(app, repository, imagesRepository) as T
             }
         }
+    }
+}
+
+private data class ImageUploadData(
+    val filename: String,
+    val contentType: String,
+    val bytes: ByteArray
+)
+
+private suspend fun ListingsViewModel.resolveImageData(uri: Uri): ImageUploadData {
+    val appContext = getApplication<Application>()
+    val resolver = appContext.contentResolver
+
+    val name = getFileName(resolver, uri) ?: "listing-${System.currentTimeMillis()}.jpg"
+    val contentType = resolver.getType(uri)?.takeIf { it.isNotBlank() }
+        ?: guessContentType(name)
+    val bytes = withContext(Dispatchers.IO) {
+        resolver.openInputStream(uri)?.use { stream ->
+            stream.readBytes()
+        }
+    } ?: throw IOException("Unable to read image bytes")
+
+    return ImageUploadData(
+        filename = name,
+        contentType = contentType,
+        bytes = bytes
+    )
+}
+
+private fun getFileName(resolver: ContentResolver, uri: Uri): String? {
+    if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
+        resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index != -1) {
+                    val name = cursor.getString(index)
+                    if (!name.isNullOrBlank()) {
+                        return name
+                    }
+                }
+            }
+        }
+    } else if (uri.scheme == ContentResolver.SCHEME_FILE) {
+        return File(uri.path ?: return null).name
+    }
+
+    return uri.lastPathSegment
+}
+
+private fun guessContentType(filename: String): String {
+    val lower = filename.lowercase(Locale.US)
+    return when {
+        lower.endsWith(".png") -> "image/png"
+        lower.endsWith(".webp") -> "image/webp"
+        lower.endsWith(".gif") -> "image/gif"
+        else -> "image/jpeg"
     }
 }


### PR DESCRIPTION
## Summary
- add an ImagesRepository that uploads listing photos through presigned MinIO URLs and confirms the upload
- wire the ListingsViewModel to collect image data, create the listing, and upload the selected photo
- update AddProductScreen to pass the picked image, expose ImagesApi from ApiClient, and capture the preview URL response

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd600268788324ae74e0c2e5b4865f