### PR TITLE
Add seller telemetry metrics flow with caching and Compose UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.services)
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -90,6 +91,9 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.datastore.preferences)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
@@ -105,6 +109,9 @@ dependencies {
     implementation(libs.material)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/androidTest/java/com/techmarketplace/presentation/telemetry/TelemetryScreenTest.kt
+++ b/app/src/androidTest/java/com/techmarketplace/presentation/telemetry/TelemetryScreenTest.kt
@@ -1,0 +1,44 @@
+package com.techmarketplace.presentation.telemetry
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.techmarketplace.presentation.telemetry.view.TelemetryScreen
+import com.techmarketplace.presentation.telemetry.viewmodel.SellerRankingRowUi
+import com.techmarketplace.presentation.telemetry.viewmodel.SellerResponseMetricsUi
+import com.techmarketplace.presentation.telemetry.viewmodel.TelemetryUiState
+import org.junit.Rule
+import org.junit.Test
+
+class TelemetryScreenTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun shows_offline_banner_when_flag_enabled() {
+        val metrics = SellerResponseMetricsUi(
+            responseRatePercent = 90,
+            averageResponseMinutes = 15.0,
+            totalConversations = 12,
+            lastUpdatedMillis = System.currentTimeMillis(),
+            ranking = listOf(SellerRankingRowUi(1, "Ana", 90, 12.0)),
+            updatedAtIso = null
+        )
+
+        composeRule.setContent {
+            TelemetryScreen(
+                state = TelemetryUiState(
+                    isLoading = false,
+                    metrics = metrics,
+                    errorMessage = null,
+                    isOffline = true
+                ),
+                onBack = {},
+                onRetry = {}
+            )
+        }
+
+        composeRule.onNodeWithText("Sin conexión. Se muestran datos en caché.").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/techmarketplace/app/MainActivity.kt
+++ b/app/src/main/java/com/techmarketplace/app/MainActivity.kt
@@ -56,6 +56,7 @@ import com.techmarketplace.presentation.onboarding.view.WelcomeScreen
 import com.techmarketplace.presentation.orders.view.OrderScreen
 import com.techmarketplace.presentation.product.view.ProductDetailRoute
 import com.techmarketplace.presentation.profile.view.ProfileRoute
+import com.techmarketplace.presentation.telemetry.view.TelemetryRoute
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import kotlinx.coroutines.launch
@@ -263,7 +264,21 @@ class MainActivity : ComponentActivity() {
                                             launchSingleTop = true
                                         }
                                     }
+                                },
+                                onOpenTelemetry = { sellerId: String ->
+                                    nav.navigate("telemetry/$sellerId") {
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
                                 }
+                            )
+                        }
+
+                        composable("telemetry/{sellerId}") { backStackEntry ->
+                            val sellerId = backStackEntry.arguments?.getString("sellerId") ?: return@composable
+                            TelemetryRoute(
+                                sellerId = sellerId,
+                                onBack = { nav.popBackStack() }
                             )
                         }
                     }

--- a/app/src/main/java/com/techmarketplace/core/data/Resource.kt
+++ b/app/src/main/java/com/techmarketplace/core/data/Resource.kt
@@ -1,0 +1,22 @@
+package com.techmarketplace.core.data
+
+/**
+ * Simple wrapper to model loading, success and error states from repositories/use cases.
+ */
+sealed class Resource<out T> {
+    data object Loading : Resource<Nothing>()
+
+    data class Success<T>(
+        val data: T,
+        /**
+         * True when the payload was fetched from the network (fresh) rather than
+         * coming from a potentially stale cache.
+         */
+        val isFresh: Boolean
+    ) : Resource<T>()
+
+    data class Error<T>(
+        val throwable: Throwable,
+        val cachedData: T? = null
+    ) : Resource<T>()
+}

--- a/app/src/main/java/com/techmarketplace/data/remote/api/TelemetryApi.kt
+++ b/app/src/main/java/com/techmarketplace/data/remote/api/TelemetryApi.kt
@@ -1,8 +1,11 @@
 package com.techmarketplace.data.remote.api
 
+import com.techmarketplace.data.remote.dto.SellerResponseMetricsDto
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 data class TelemetryEvent(
     val event_type: String,
@@ -24,4 +27,9 @@ interface TelemetryApi {
         @Header("Authorization") bearer: String?, // null si no lo pides
         @Body body: TelemetryBatch
     )
+
+    @GET("telemetry/sellers/{sellerId}/response-metrics")
+    suspend fun getSellerResponseMetrics(
+        @Path("sellerId") sellerId: String
+    ): SellerResponseMetricsDto
 }

--- a/app/src/main/java/com/techmarketplace/data/remote/dto/TelemetryDtos.kt
+++ b/app/src/main/java/com/techmarketplace/data/remote/dto/TelemetryDtos.kt
@@ -1,0 +1,44 @@
+package com.techmarketplace.data.remote.dto
+
+import com.techmarketplace.data.storage.dao.SellerRankingEntryEntity
+import com.techmarketplace.data.storage.dao.SellerResponseMetricsEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SellerRankingEntryDto(
+    @SerialName("seller_id") val sellerId: String,
+    @SerialName("seller_name") val sellerName: String? = null,
+    @SerialName("response_rate") val responseRate: Double? = null,
+    @SerialName("average_response_minutes") val averageResponseMinutes: Double? = null,
+    @SerialName("percentile") val percentile: Double? = null
+)
+
+@Serializable
+data class SellerResponseMetricsDto(
+    @SerialName("seller_id") val sellerId: String,
+    @SerialName("response_rate") val responseRate: Double,
+    @SerialName("average_response_minutes") val averageResponseMinutes: Double,
+    @SerialName("total_conversations") val totalConversations: Int,
+    @SerialName("ranking") val ranking: List<SellerRankingEntryDto> = emptyList(),
+    @SerialName("updated_at") val updatedAt: String? = null
+)
+
+fun SellerResponseMetricsDto.toEntity(fetchedAt: Long): SellerResponseMetricsEntity =
+    SellerResponseMetricsEntity(
+        sellerId = sellerId,
+        responseRate = responseRate,
+        averageResponseMinutes = averageResponseMinutes,
+        totalConversations = totalConversations,
+        ranking = ranking.map { entry ->
+            SellerRankingEntryEntity(
+                sellerId = entry.sellerId,
+                sellerName = entry.sellerName,
+                responseRate = entry.responseRate ?: 0.0,
+                averageResponseMinutes = entry.averageResponseMinutes ?: 0.0,
+                percentile = entry.percentile
+            )
+        },
+        fetchedAt = fetchedAt,
+        updatedAtIso = updatedAt
+    )

--- a/app/src/main/java/com/techmarketplace/data/repository/TelemetryRepositoryImpl.kt
+++ b/app/src/main/java/com/techmarketplace/data/repository/TelemetryRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package com.techmarketplace.data.repository
+
+import com.techmarketplace.data.remote.ApiClient
+import com.techmarketplace.data.remote.api.TelemetryApi
+import com.techmarketplace.data.remote.dto.toEntity
+import com.techmarketplace.data.storage.dao.SellerMetricsDao
+import com.techmarketplace.data.storage.dao.TelemetryDatabaseProvider
+import com.techmarketplace.data.storage.dao.toDomain
+import com.techmarketplace.domain.telemetry.SellerResponseMetrics
+import com.techmarketplace.domain.telemetry.TelemetryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class TelemetryRepositoryImpl(
+    private val api: TelemetryApi,
+    private val dao: SellerMetricsDao,
+    private val now: () -> Long = { System.currentTimeMillis() }
+) : TelemetryRepository {
+
+    override fun observeSellerResponseMetrics(sellerId: String): Flow<SellerResponseMetrics?> =
+        dao.observeMetrics(sellerId).map { entity -> entity?.toDomain() }
+
+    override suspend fun getCachedSellerResponseMetrics(sellerId: String): SellerResponseMetrics? =
+        dao.getMetrics(sellerId)?.toDomain()
+
+    override suspend fun refreshSellerResponseMetrics(sellerId: String) {
+        val dto = api.getSellerResponseMetrics(sellerId)
+        val entity = dto.toEntity(now())
+        dao.insertMetrics(entity)
+    }
+
+    override suspend fun isCacheExpired(sellerId: String, ttlMillis: Long): Boolean {
+        val entity = dao.getMetrics(sellerId) ?: return true
+        return now() - entity.fetchedAt > ttlMillis
+    }
+
+    companion object {
+        fun create(context: android.content.Context): TelemetryRepositoryImpl {
+            val db = TelemetryDatabaseProvider.get(context)
+            return TelemetryRepositoryImpl(ApiClient.telemetryApi(), db.sellerMetricsDao())
+        }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/SellerMetricsDao.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/SellerMetricsDao.kt
@@ -1,0 +1,22 @@
+package com.techmarketplace.data.storage.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SellerMetricsDao {
+    @Query("SELECT * FROM seller_response_metrics WHERE sellerId = :sellerId LIMIT 1")
+    fun observeMetrics(sellerId: String): Flow<SellerResponseMetricsEntity?>
+
+    @Query("SELECT * FROM seller_response_metrics WHERE sellerId = :sellerId LIMIT 1")
+    suspend fun getMetrics(sellerId: String): SellerResponseMetricsEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMetrics(entity: SellerResponseMetricsEntity)
+
+    @Query("DELETE FROM seller_response_metrics WHERE sellerId = :sellerId")
+    suspend fun deleteBySellerId(sellerId: String)
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/SellerResponseMetricsEntity.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/SellerResponseMetricsEntity.kt
@@ -1,0 +1,46 @@
+package com.techmarketplace.data.storage.dao
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.techmarketplace.domain.telemetry.SellerRankingEntry
+import com.techmarketplace.domain.telemetry.SellerResponseMetrics
+import kotlinx.serialization.Serializable
+
+@Entity(tableName = "seller_response_metrics")
+data class SellerResponseMetricsEntity(
+    @PrimaryKey val sellerId: String,
+    val responseRate: Double,
+    val averageResponseMinutes: Double,
+    val totalConversations: Int,
+    val ranking: List<SellerRankingEntryEntity>,
+    val fetchedAt: Long,
+    val updatedAtIso: String?
+)
+
+@Serializable
+data class SellerRankingEntryEntity(
+    val sellerId: String,
+    val sellerName: String?,
+    val responseRate: Double,
+    val averageResponseMinutes: Double,
+    val percentile: Double?
+)
+
+fun SellerResponseMetricsEntity.toDomain(): SellerResponseMetrics =
+    SellerResponseMetrics(
+        sellerId = sellerId,
+        responseRate = responseRate,
+        averageResponseMinutes = averageResponseMinutes,
+        totalConversations = totalConversations,
+        ranking = ranking.map { entry ->
+            SellerRankingEntry(
+                sellerId = entry.sellerId,
+                sellerName = entry.sellerName,
+                responseRate = entry.responseRate,
+                averageResponseMinutes = entry.averageResponseMinutes,
+                percentile = entry.percentile
+            )
+        },
+        fetchedAt = fetchedAt,
+        updatedAtIso = updatedAtIso
+    )

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/TelemetryDatabase.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/TelemetryDatabase.kt
@@ -1,0 +1,36 @@
+package com.techmarketplace.data.storage.dao
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(
+    entities = [SellerResponseMetricsEntity::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(TelemetryTypeConverters::class)
+abstract class TelemetryDatabase : RoomDatabase() {
+    abstract fun sellerMetricsDao(): SellerMetricsDao
+}
+
+object TelemetryDatabaseProvider {
+    @Volatile
+    private var instance: TelemetryDatabase? = null
+
+    fun get(context: Context): TelemetryDatabase {
+        return instance ?: synchronized(this) {
+            instance ?: buildDatabase(context.applicationContext).also { instance = it }
+        }
+    }
+
+    private fun buildDatabase(context: Context): TelemetryDatabase =
+        Room.databaseBuilder(
+            context,
+            TelemetryDatabase::class.java,
+            "telemetry.db"
+        ).fallbackToDestructiveMigration()
+            .build()
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/TelemetryTypeConverters.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/TelemetryTypeConverters.kt
@@ -1,0 +1,19 @@
+package com.techmarketplace.data.storage.dao
+
+import androidx.room.TypeConverter
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+object TelemetryTypeConverters {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val rankingSerializer = ListSerializer(SellerRankingEntryEntity.serializer())
+
+    @TypeConverter
+    fun toRanking(jsonString: String?): List<SellerRankingEntryEntity> =
+        jsonString?.let { json.decodeFromString(rankingSerializer, it) } ?: emptyList()
+
+    @TypeConverter
+    fun fromRanking(entries: List<SellerRankingEntryEntity>): String =
+        json.encodeToString(rankingSerializer, entries)
+}

--- a/app/src/main/java/com/techmarketplace/domain/telemetry/ObserveSellerResponseMetricsUseCase.kt
+++ b/app/src/main/java/com/techmarketplace/domain/telemetry/ObserveSellerResponseMetricsUseCase.kt
@@ -1,0 +1,108 @@
+package com.techmarketplace.domain.telemetry
+
+import com.techmarketplace.core.data.Resource
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+
+class ObserveSellerResponseMetricsUseCase(
+    private val repository: TelemetryRepository,
+    private val connectivityFlow: Flow<Boolean>,
+    private val ttlMillis: Long = TimeUnit.MINUTES.toMillis(15),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+
+    operator fun invoke(sellerId: String): Flow<Resource<SellerResponseMetrics>> = channelFlow {
+        trySend(Resource.Loading)
+
+        val cacheJob = repository.observeSellerResponseMetrics(sellerId)
+            .onEach { metrics ->
+                metrics?.let {
+                    val isFresh = System.currentTimeMillis() - it.fetchedAt <= ttlMillis
+                    trySend(Resource.Success(it, isFresh))
+                }
+            }
+            .launchIn(this)
+
+        val cached = repository.getCachedSellerResponseMetrics(sellerId)
+        val needsRefresh = cached == null || System.currentTimeMillis() - cached.fetchedAt > ttlMillis
+        if (needsRefresh) {
+            refreshWithRetry(sellerId)
+        }
+
+        awaitClose { cacheJob.cancel() }
+    }
+
+    suspend fun refresh(sellerId: String): Result<Unit> =
+        refreshOutsideChannel(sellerId).map { }
+
+    private suspend fun ProducerScope<Resource<SellerResponseMetrics>>.refreshWithRetry(
+        sellerId: String,
+        emitErrors: Boolean = true
+    ): Result<Boolean> {
+        var shouldRetry: Boolean
+        var lastError: Throwable? = null
+        do {
+            shouldRetry = false
+            val result = runCatching {
+                withContext(dispatcher) { repository.refreshSellerResponseMetrics(sellerId) }
+                true
+            }
+
+            result.exceptionOrNull()?.let { error ->
+                lastError = error
+                if (emitErrors) {
+                    val cached = repository.getCachedSellerResponseMetrics(sellerId)
+                    trySend(Resource.Error(error, cached))
+                }
+                if (error is IOException) {
+                    connectivityFlow.filter { it }.first()
+                    shouldRetry = true
+                }
+            }
+        } while (shouldRetry)
+
+        return if (lastError == null) {
+            Result.success(true)
+        } else {
+            Result.failure(lastError!!)
+        }
+    }
+
+    private suspend fun refreshOutsideChannel(
+        sellerId: String
+    ): Result<Boolean> {
+        var shouldRetry: Boolean
+        var lastError: Throwable? = null
+        do {
+            shouldRetry = false
+            val result = runCatching {
+                withContext(dispatcher) { repository.refreshSellerResponseMetrics(sellerId) }
+                true
+            }
+            result.exceptionOrNull()?.let { error ->
+                lastError = error
+                if (error is IOException) {
+                    connectivityFlow.filter { it }.first()
+                    shouldRetry = true
+                }
+            }
+        } while (shouldRetry)
+
+        return if (lastError == null) {
+            Result.success(true)
+        } else {
+            Result.failure(lastError!!)
+        }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/domain/telemetry/SellerResponseMetrics.kt
+++ b/app/src/main/java/com/techmarketplace/domain/telemetry/SellerResponseMetrics.kt
@@ -1,0 +1,21 @@
+package com.techmarketplace.domain.telemetry
+
+data class SellerRankingEntry(
+    val sellerId: String,
+    val sellerName: String?,
+    val responseRate: Double,
+    val averageResponseMinutes: Double,
+    val percentile: Double?
+)
+
+data class SellerResponseMetrics(
+    val sellerId: String,
+    val responseRate: Double,
+    val averageResponseMinutes: Double,
+    val totalConversations: Int,
+    val ranking: List<SellerRankingEntry>,
+    /** Epoch milliseconds when the snapshot was stored locally. */
+    val fetchedAt: Long,
+    /** Optional ISO date from backend for extra context. */
+    val updatedAtIso: String?
+)

--- a/app/src/main/java/com/techmarketplace/domain/telemetry/TelemetryRepository.kt
+++ b/app/src/main/java/com/techmarketplace/domain/telemetry/TelemetryRepository.kt
@@ -1,0 +1,13 @@
+package com.techmarketplace.domain.telemetry
+
+import kotlinx.coroutines.flow.Flow
+
+interface TelemetryRepository {
+    fun observeSellerResponseMetrics(sellerId: String): Flow<SellerResponseMetrics?>
+
+    suspend fun getCachedSellerResponseMetrics(sellerId: String): SellerResponseMetrics?
+
+    suspend fun refreshSellerResponseMetrics(sellerId: String)
+
+    suspend fun isCacheExpired(sellerId: String, ttlMillis: Long): Boolean
+}

--- a/app/src/main/java/com/techmarketplace/presentation/profile/view/ProfileRoute.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/profile/view/ProfileRoute.kt
@@ -8,11 +8,13 @@ import com.techmarketplace.core.ui.BottomItem
 fun ProfileRoute(
     onNavigateBottom: (BottomItem) -> Unit,
     onOpenListing: (String) -> Unit,
-    onSignOut: () -> Unit
+    onSignOut: () -> Unit,
+    onOpenTelemetry: (String) -> Unit
 ) {
     ProfileScreen(
         onNavigateBottom = onNavigateBottom,
         onOpenListing = onOpenListing,
-        onSignOut = onSignOut
+        onSignOut = onSignOut,
+        onOpenTelemetry = onOpenTelemetry
     )
 }

--- a/app/src/main/java/com/techmarketplace/presentation/profile/view/ProfileScreen.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/profile/view/ProfileScreen.kt
@@ -43,7 +43,8 @@ import retrofit2.HttpException
 fun ProfileScreen(
     onNavigateBottom: (BottomItem) -> Unit,
     onOpenListing: (String) -> Unit,
-    onSignOut: () -> Unit
+    onSignOut: () -> Unit,
+    onOpenTelemetry: (String) -> Unit
 ) {
     val ctx = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -281,6 +282,15 @@ fun ProfileScreen(
                                 Spacer(Modifier.width(8.dp))
                             }
                             Text("Actualizar")
+                        }
+                        OutlinedButton(
+                            onClick = {
+                                userId?.let(onOpenTelemetry)
+                            },
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(28.dp)
+                        ) {
+                            Text("Ver métricas")
                         }
                         Button(
                             onClick = onSignOut,

--- a/app/src/main/java/com/techmarketplace/presentation/telemetry/view/TelemetryScreen.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/telemetry/view/TelemetryScreen.kt
@@ -1,104 +1,423 @@
-@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
-
 package com.techmarketplace.presentation.telemetry.view
 
+import android.app.Application
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.techmarketplace.core.designsystem.GreenDark
+import com.techmarketplace.presentation.telemetry.viewmodel.SellerRankingRowUi
+import com.techmarketplace.presentation.telemetry.viewmodel.SellerResponseMetricsUi
+import com.techmarketplace.presentation.telemetry.viewmodel.TelemetryUiState
+import com.techmarketplace.presentation.telemetry.viewmodel.TelemetryViewModel
+import java.text.NumberFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
-/**
- * Pantalla de Telemetría (dummy/placeholder)
- * - Sin llamadas a backend para evitar dependencias
- * - Con tipos explícitos en lambdas para evitar "Cannot infer type"
- */
-
-data class TelemetryRow(
-    val eventType: String,
-    val occurredAt: String,
-    val details: String
-)
+@Composable
+fun TelemetryRoute(
+    sellerId: String,
+    onBack: () -> Unit,
+    viewModel: TelemetryViewModel = run {
+        val context = LocalContext.current
+        val app = context.applicationContext as Application
+        viewModel(factory = TelemetryViewModel.factory(app))
+    }
+) {
+    LaunchedEffect(sellerId) { viewModel.observeSeller(sellerId) }
+    val uiState by viewModel.uiState.collectAsState()
+    TelemetryScreen(
+        state = uiState,
+        onBack = onBack,
+        onRetry = { viewModel.refresh() }
+    )
+}
 
 @Composable
 fun TelemetryScreen(
-    onBack: (() -> Unit)? = null
+    state: TelemetryUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit
 ) {
-    // Lista de ejemplo; en el futuro la puedes poblar desde tu API.
-    val rows: List<TelemetryRow> = remember {
-        listOf(
-            TelemetryRow("search.performed", "2025-10-12 16:21", """{"q": "laptop", "page": 1}"""),
-            TelemetryRow("listing.view",     "2025-10-12 16:25", """{"listing_id": "L1"}"""),
-            TelemetryRow("checkout.step",    "2025-10-12 16:40", """{"step": "payment"}""")
-        )
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Telemetry") },
+                title = { Text("Respuesta del vendedor") },
                 navigationIcon = {
-                    if (onBack != null) {
-                        IconButton(onClick = onBack) {
-                            Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                        }
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Regresar")
                     }
                 }
             )
         }
-    ) { innerPadding: PaddingValues ->
-        LazyColumn(
+    ) { padding ->
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            content = {
-                // 👇 Tipado explícito para evitar problemas de inferencia:
-                items<TelemetryRow>(rows) { row: TelemetryRow ->
-                    TelemetryRowItem(row = row)
-                    Divider()
+                .padding(padding)
+        ) {
+            AnimatedVisibility(
+                visible = state.isOffline,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                OfflineBanner(onRetry)
+            }
+
+            when {
+                state.isLoading && state.metrics == null -> {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                state.metrics != null -> {
+                    TelemetryContent(
+                        metrics = state.metrics,
+                        isLoading = state.isLoading,
+                        errorMessage = state.errorMessage,
+                        onRetry = onRetry
+                    )
+                }
+
+                else -> {
+                    ErrorContent(message = state.errorMessage, onRetry = onRetry)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TelemetryContent(
+    metrics: SellerResponseMetricsUi,
+    isLoading: Boolean,
+    errorMessage: String?,
+    onRetry: () -> Unit
+) {
+    val numberFormat = remember { NumberFormat.getPercentInstance().apply { maximumFractionDigits = 0 } }
+    val lastUpdated = remember(metrics.lastUpdatedMillis) {
+        val date = Date(metrics.lastUpdatedMillis)
+        SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault()).format(date)
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                tonalElevation = 2.dp,
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Resumen", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(12.dp))
+                    SummaryRow(
+                        label = "Tasa de respuesta",
+                        value = numberFormat.format(metrics.responseRatePercent / 100.0),
+                        progress = metrics.responseRatePercent / 100f
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    SummaryRow(
+                        label = "Tiempo promedio",
+                        value = String.format(Locale.getDefault(), "%.1f min", metrics.averageResponseMinutes),
+                        progress = (1f - (metrics.averageResponseMinutes / 60f)).coerceIn(0f, 1f)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = "Conversaciones analizadas: ${metrics.totalConversations}",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = "Última actualización: $lastUpdated",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    metrics.updatedAtIso?.let {
+                        Text(
+                            text = "Backend: $it",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+
+        if (!errorMessage.isNullOrBlank()) {
+            item {
+                ErrorBanner(message = errorMessage, onRetry = onRetry)
+            }
+        }
+
+        if (metrics.ranking.isNotEmpty()) {
+            item { RankingChart(metrics.ranking) }
+            items(metrics.ranking) { entry ->
+                RankingRow(entry)
+                Divider()
+            }
+        } else {
+            item {
+                Text("Sin datos de ranking todavía", modifier = Modifier.padding(8.dp))
+            }
+        }
+
+        if (isLoading) {
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RankingChart(
+    ranking: List<SellerRankingRowUi>
+) {
+    val maxValue = ranking.maxOfOrNull { it.responseRatePercent }?.coerceAtLeast(1) ?: 1
+    val barHeight = remember { 180.dp }
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        tonalElevation = 2.dp,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Ranking de respuesta", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(16.dp))
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(barHeight)
+            ) {
+                val barWidth = size.width / (ranking.size * 2f)
+                ranking.forEachIndexed { index, entry ->
+                    val barLeft = (index * 2 + 0.5f) * barWidth
+                    val barTop = size.height - (entry.responseRatePercent / maxValue.toFloat()) * size.height
+                    val color = if (index == 0) GreenDark else MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                    drawRect(
+                        color = color,
+                        topLeft = Offset(barLeft, barTop),
+                        size = androidx.compose.ui.geometry.Size(barWidth, size.height - barTop)
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ranking.take(3).forEachIndexed { index, entry ->
+                    Surface(
+                        color = if (index == 0) GreenDark else MaterialTheme.colorScheme.surfaceVariant,
+                        shape = MaterialTheme.shapes.small,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .background(Color.Transparent)
+                            .padding(4.dp)
+                    ) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(4.dp)
+                                .background(Color.Transparent)
+                        ) {
+                            Text(
+                                text = "Top ${index + 1}\n${entry.responseRatePercent}%",
+                                color = if (index == 0) Color.White else MaterialTheme.colorScheme.onSurface,
+                                fontSize = 12.sp
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RankingRow(entry: SellerRankingRowUi) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("#${entry.position} ${entry.sellerName}", fontWeight = FontWeight.SemiBold)
+            Text("${entry.averageResponseMinutes.formatMinutes()} • ${entry.responseRatePercent}% de respuesta",
+                style = MaterialTheme.typography.bodySmall)
+        }
+        CircularBadge(entry.responseRatePercent)
+    }
+}
+
+private fun Double.formatMinutes(): String = String.format(Locale.getDefault(), "%.1f min", this)
+
+@Composable
+private fun CircularBadge(value: Int) {
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = GreenDark.copy(alpha = 0.85f)
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("$value%", color = Color.White, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun SummaryRow(label: String, value: String, progress: Float) {
+    Column {
+        Text(label, style = MaterialTheme.typography.labelLarge)
+        Spacer(Modifier.height(4.dp))
+        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(8.dp))
+        ProgressBar(progress = progress)
+    }
+}
+
+@Composable
+private fun ProgressBar(progress: Float, height: Dp = 8.dp) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(height)
+            .background(MaterialTheme.colorScheme.surfaceVariant, shape = MaterialTheme.shapes.small)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress)
+                .height(height)
+                .background(GreenDark, shape = MaterialTheme.shapes.small)
         )
     }
 }
 
 @Composable
-private fun TelemetryRowItem(row: TelemetryRow) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
-    ) {
-        Text(
-            text = row.eventType,
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
-        )
-        Text(
-            text = row.occurredAt,
-            style = MaterialTheme.typography.bodySmall
-        )
-        Text(
-            text = row.details,
-            style = MaterialTheme.typography.bodyMedium
-        )
+private fun OfflineBanner(onRetry: () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.errorContainer, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("Sin conexión. Se muestran datos en caché.")
+            Button(onClick = onRetry) {
+                Text("Reintentar")
+            }
+        }
     }
+}
+
+@Composable
+private fun ErrorBanner(message: String, onRetry: () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.errorContainer, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("No se pudieron actualizar los datos", fontWeight = FontWeight.SemiBold)
+                Text(message, style = MaterialTheme.typography.bodySmall)
+            }
+            Button(onClick = onRetry) { Text("Reintentar") }
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(message: String?, onRetry: () -> Unit) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(message ?: "No hay métricas disponibles")
+            Button(onClick = onRetry) { Text("Reintentar") }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TelemetryScreenPreview() {
+    val ranking = listOf(
+        SellerRankingRowUi(1, "Ana", 95, 12.0),
+        SellerRankingRowUi(2, "Luis", 88, 18.0),
+        SellerRankingRowUi(3, "Carla", 75, 25.0)
+    )
+    val metrics = SellerResponseMetricsUi(
+        responseRatePercent = 92,
+        averageResponseMinutes = 14.5,
+        totalConversations = 48,
+        lastUpdatedMillis = System.currentTimeMillis(),
+        ranking = ranking,
+        updatedAtIso = "2024-10-12T18:22:00Z"
+    )
+    TelemetryScreen(
+        state = TelemetryUiState(
+            isLoading = false,
+            metrics = metrics,
+            errorMessage = null,
+            isOffline = false
+        ),
+        onBack = {},
+        onRetry = {}
+    )
 }

--- a/app/src/main/java/com/techmarketplace/presentation/telemetry/viewmodel/TelemetryViewModel.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/telemetry/viewmodel/TelemetryViewModel.kt
@@ -1,0 +1,138 @@
+package com.techmarketplace.presentation.telemetry.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.techmarketplace.core.connectivity.ConnectivityObserver
+import com.techmarketplace.core.data.Resource
+import com.techmarketplace.data.repository.TelemetryRepositoryImpl
+import com.techmarketplace.domain.telemetry.ObserveSellerResponseMetricsUseCase
+import com.techmarketplace.domain.telemetry.SellerRankingEntry
+import com.techmarketplace.domain.telemetry.SellerResponseMetrics
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class SellerRankingRowUi(
+    val position: Int,
+    val sellerName: String,
+    val responseRatePercent: Int,
+    val averageResponseMinutes: Double
+)
+
+data class SellerResponseMetricsUi(
+    val responseRatePercent: Int,
+    val averageResponseMinutes: Double,
+    val totalConversations: Int,
+    val lastUpdatedMillis: Long,
+    val ranking: List<SellerRankingRowUi>,
+    val updatedAtIso: String?
+)
+
+data class TelemetryUiState(
+    val isLoading: Boolean = false,
+    val metrics: SellerResponseMetricsUi? = null,
+    val errorMessage: String? = null,
+    val isOffline: Boolean = false
+)
+
+class TelemetryViewModel(
+    application: Application,
+    private val useCase: ObserveSellerResponseMetricsUseCase
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow(TelemetryUiState(isLoading = true))
+    val uiState: StateFlow<TelemetryUiState> = _uiState.asStateFlow()
+
+    private var currentSellerId: String? = null
+    private var observeJob: Job? = null
+
+    fun observeSeller(sellerId: String) {
+        if (sellerId == currentSellerId && observeJob?.isActive == true) return
+        currentSellerId = sellerId
+        observeJob?.cancel()
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        observeJob = viewModelScope.launch {
+            useCase(sellerId).collect { resource ->
+                when (resource) {
+                    is Resource.Loading -> _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                    is Resource.Success -> _uiState.value = TelemetryUiState(
+                        isLoading = false,
+                        metrics = resource.data.toUi(),
+                        errorMessage = null,
+                        isOffline = !resource.isFresh
+                    )
+                    is Resource.Error -> {
+                        _uiState.update { state ->
+                            state.copy(
+                                isLoading = false,
+                                metrics = resource.cachedData?.toUi() ?: state.metrics,
+                                errorMessage = resource.throwable.message ?: "No se pudo obtener métricas",
+                                isOffline = resource.throwable is IOException
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun refresh() {
+        val sellerId = currentSellerId ?: return
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            val result = useCase.refresh(sellerId)
+            result.exceptionOrNull()?.let { error ->
+                _uiState.update { state ->
+                    state.copy(
+                        isLoading = false,
+                        errorMessage = error.message ?: "No se pudo actualizar",
+                        isOffline = error is IOException
+                    )
+                }
+            }
+        }
+    }
+
+    private fun SellerResponseMetrics.toUi(): SellerResponseMetricsUi =
+        SellerResponseMetricsUi(
+            responseRatePercent = (responseRate * 100).toInt().coerceIn(0, 100),
+            averageResponseMinutes = averageResponseMinutes,
+            totalConversations = totalConversations,
+            lastUpdatedMillis = fetchedAt,
+            ranking = ranking.mapIndexed { index, entry -> entry.toUi(index) },
+            updatedAtIso = updatedAtIso
+        )
+
+    private fun SellerRankingEntry.toUi(position: Int): SellerRankingRowUi =
+        SellerRankingRowUi(
+            position = position + 1,
+            sellerName = sellerName?.ifBlank { sellerId } ?: sellerId,
+            responseRatePercent = (responseRate * 100).toInt().coerceIn(0, 100),
+            averageResponseMinutes = averageResponseMinutes
+        )
+
+    companion object {
+        fun factory(app: Application): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val repository = TelemetryRepositoryImpl.create(app)
+                val connectivity = ConnectivityObserver.observe(app)
+                val useCase = ObserveSellerResponseMetricsUseCase(
+                    repository = repository,
+                    connectivityFlow = connectivity,
+                    ttlMillis = TimeUnit.MINUTES.toMillis(15)
+                )
+                return TelemetryViewModel(app, useCase) as T
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/techmarketplace/data/repository/TelemetryRepositoryImplTest.kt
+++ b/app/src/test/java/com/techmarketplace/data/repository/TelemetryRepositoryImplTest.kt
@@ -1,0 +1,104 @@
+package com.techmarketplace.data.repository
+
+import com.techmarketplace.data.remote.api.TelemetryApi
+import com.techmarketplace.data.remote.api.TelemetryBatch
+import com.techmarketplace.data.remote.dto.SellerRankingEntryDto
+import com.techmarketplace.data.remote.dto.SellerResponseMetricsDto
+import com.techmarketplace.data.storage.dao.SellerMetricsDao
+import com.techmarketplace.data.storage.dao.SellerResponseMetricsEntity
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TelemetryRepositoryImplTest {
+
+    private val now = AtomicLong(0L)
+    private val dao = InMemorySellerMetricsDao()
+    private val api = FakeTelemetryApi()
+    private val repository = TelemetryRepositoryImpl(api, dao, now::get)
+
+    @Test
+    fun refresh_inserts_and_emits_metrics() = runTest {
+        val dto = SellerResponseMetricsDto(
+            sellerId = "seller-1",
+            responseRate = 0.9,
+            averageResponseMinutes = 12.0,
+            totalConversations = 30,
+            ranking = listOf(
+                SellerRankingEntryDto("seller-1", "Alice", 0.9, 12.0, 0.95),
+                SellerRankingEntryDto("seller-2", "Bob", 0.8, 15.0, 0.82)
+            ),
+            updatedAt = "2024-01-01T00:00:00Z"
+        )
+        api.next = dto
+
+        repository.refreshSellerResponseMetrics("seller-1")
+
+        val cached = repository.getCachedSellerResponseMetrics("seller-1")
+        assertEquals("seller-1", cached?.sellerId)
+        assertEquals(12.0, cached?.averageResponseMinutes, 0.0)
+
+        val emission = repository.observeSellerResponseMetrics("seller-1").first()
+        assertEquals(30, emission?.totalConversations)
+        assertEquals(2, emission?.ranking?.size)
+    }
+
+    @Test
+    fun isCacheExpired_respects_ttl() = runTest {
+        val entity = SellerResponseMetricsEntity(
+            sellerId = "seller-1",
+            responseRate = 0.7,
+            averageResponseMinutes = 20.0,
+            totalConversations = 10,
+            ranking = emptyList(),
+            fetchedAt = 0L,
+            updatedAtIso = null
+        )
+        dao.insertMetrics(entity)
+
+        now.set(1_000L)
+        assertFalse(repository.isCacheExpired("seller-1", ttlMillis = 2_000L))
+
+        now.set(5_000L)
+        assertTrue(repository.isCacheExpired("seller-1", ttlMillis = 2_000L))
+    }
+}
+
+private class FakeTelemetryApi : TelemetryApi {
+    var next: SellerResponseMetricsDto? = null
+
+    override suspend fun ingest(bearer: String?, body: TelemetryBatch) {
+        // no-op for tests
+    }
+
+    override suspend fun getSellerResponseMetrics(sellerId: String): SellerResponseMetricsDto {
+        return next ?: error("No metrics stubbed")
+    }
+}
+
+private class InMemorySellerMetricsDao : SellerMetricsDao {
+    private val state = MutableStateFlow<SellerResponseMetricsEntity?>(null)
+
+    override fun observeMetrics(sellerId: String): Flow<SellerResponseMetricsEntity?> =
+        state.map { entity -> if (entity?.sellerId == sellerId) entity else null }
+
+    override suspend fun getMetrics(sellerId: String): SellerResponseMetricsEntity? =
+        state.value?.takeIf { it.sellerId == sellerId }
+
+    override suspend fun insertMetrics(entity: SellerResponseMetricsEntity) {
+        state.value = entity
+    }
+
+    override suspend fun deleteBySellerId(sellerId: String) {
+        if (state.value?.sellerId == sellerId) {
+            state.value = null
+        }
+    }
+}

--- a/app/src/test/java/com/techmarketplace/domain/telemetry/ObserveSellerResponseMetricsUseCaseTest.kt
+++ b/app/src/test/java/com/techmarketplace/domain/telemetry/ObserveSellerResponseMetricsUseCaseTest.kt
@@ -1,0 +1,112 @@
+package com.techmarketplace.domain.telemetry
+
+import com.techmarketplace.core.data.Resource
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveSellerResponseMetricsUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Test
+    fun emits_cached_metrics_before_refresh() = runTest(testDispatcher) {
+        val repository = FakeTelemetryRepository()
+        val cached = sampleMetrics(fetchedAt = System.currentTimeMillis())
+        repository.current.value = cached
+        repository.cacheExpired = false
+        val connectivity = MutableStateFlow(true)
+        val useCase = ObserveSellerResponseMetricsUseCase(repository, connectivity, ttlMillis = 10_000L, dispatcher = testDispatcher)
+
+        val emissions = mutableListOf<Resource<SellerResponseMetrics>>()
+        val job = launch { useCase("seller-1").collect { emissions += it; if (emissions.size == 2) cancel() } }
+
+        advanceUntilIdle()
+        assertEquals(2, emissions.size)
+        assertTrue(emissions[0] is Resource.Loading)
+        val success = emissions[1] as Resource.Success
+        assertEquals(cached, success.data)
+        assertTrue(success.isFresh)
+
+        job.cancel()
+    }
+
+    @Test
+    fun retries_refresh_when_offline_then_emits_fresh_data() = runTest(testDispatcher) {
+        val repository = FakeTelemetryRepository()
+        val cached = sampleMetrics(fetchedAt = 0L)
+        repository.current.value = cached
+        repository.cacheExpired = true
+        repository.failNextRefresh = IOException("offline")
+
+        val connectivity = MutableStateFlow(false)
+        val useCase = ObserveSellerResponseMetricsUseCase(repository, connectivity, ttlMillis = 10L, dispatcher = testDispatcher)
+
+        val emissions = mutableListOf<Resource<SellerResponseMetrics>>()
+        val job = launch {
+            useCase("seller-1").collect { emissions += it; if (emissions.size >= 4) cancel() }
+        }
+
+        advanceUntilIdle()
+        assertTrue(emissions.any { it is Resource.Error })
+        assertTrue(repository.refreshCalled.get())
+
+        repository.failNextRefresh = null
+        repository.nextAfterRefresh = cached.copy(responseRate = 0.95, fetchedAt = System.currentTimeMillis() + 2_000L)
+        connectivity.value = true
+
+        advanceUntilIdle()
+
+        val last = emissions.last { it is Resource.Success } as Resource.Success
+        assertEquals(0.95, last.data.responseRate, 0.0)
+        assertTrue(last.isFresh)
+
+        job.cancel()
+    }
+}
+
+private class FakeTelemetryRepository : TelemetryRepository {
+    val current = MutableStateFlow<SellerResponseMetrics?>(null)
+    var cacheExpired: Boolean = false
+    var failNextRefresh: Throwable? = null
+    var nextAfterRefresh: SellerResponseMetrics? = null
+    val refreshCalled = AtomicBoolean(false)
+
+    override fun observeSellerResponseMetrics(sellerId: String): Flow<SellerResponseMetrics?> = current
+
+    override suspend fun getCachedSellerResponseMetrics(sellerId: String): SellerResponseMetrics? = current.value
+
+    override suspend fun refreshSellerResponseMetrics(sellerId: String) {
+        refreshCalled.set(true)
+        failNextRefresh?.let {
+            failNextRefresh = null
+            throw it
+        }
+        nextAfterRefresh?.let { current.value = it }
+    }
+
+    override suspend fun isCacheExpired(sellerId: String, ttlMillis: Long): Boolean = cacheExpired
+}
+
+private fun sampleMetrics(fetchedAt: Long): SellerResponseMetrics = SellerResponseMetrics(
+    sellerId = "seller-1",
+    responseRate = 0.9,
+    averageResponseMinutes = 10.0,
+    totalConversations = 5,
+    ranking = listOf(
+        SellerRankingEntry("seller-1", "Ana", 0.9, 10.0, 0.95)
+    ),
+    fetchedAt = fetchedAt,
+    updatedAtIso = null
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ coroutines = "1.8.1"
 coil = "2.6.0"
 lifecycle = "2.8.6"
 material = "1.13.0"
+room = "2.6.1"
+compose-ui-test = "1.7.3"
 
 # ÚNICAS versiones para Firebase y Play Services (sin duplicados)
 firebase-bom = "33.3.0"
@@ -73,3 +75,9 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 androidx-compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose-ui-test" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui-test" }


### PR DESCRIPTION
## Summary
- add Retrofit DTOs, API endpoint, and Room cache for seller response metrics with TTL metadata
- implement telemetry repository, domain models, use case, and ViewModel exposing cached/network merged state
- refresh the telemetry screen UI, add navigation from profile, and cover logic with unit and Compose UI tests

## Testing
- `./gradlew test` *(fails: Android SDK missing in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f904b211c8324bb2139c9f5316854)