### PR TITLE
Hook cart UI to backend data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     kapt(libs.androidx.room.compiler)
+    implementation(libs.androidx.work.runtime.ktx)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)

--- a/app/src/androidTest/java/com/techmarketplace/cart/CartRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/techmarketplace/cart/CartRepositoryImplTest.kt
@@ -1,0 +1,161 @@
+package com.techmarketplace.cart
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.techmarketplace.data.remote.api.CartFetchResult
+import com.techmarketplace.data.remote.api.CartRemoteDataSource
+import com.techmarketplace.data.remote.api.CartRemoteItem
+import com.techmarketplace.data.storage.CartPreferences
+import com.techmarketplace.data.storage.cart.CartLocalDataSource
+import com.techmarketplace.data.storage.dao.CartDatabase
+import com.techmarketplace.data.storage.dao.CartTypeConverters
+import com.techmarketplace.domain.cart.CartItemUpdate
+import com.techmarketplace.domain.cart.CartSyncOperation
+import com.techmarketplace.domain.cart.CartVariantDetail
+import com.techmarketplace.data.repository.cart.CartRepositoryImpl
+import com.techmarketplace.data.storage.cart.CartLocalDataSource.Companion.buildCartItemId
+import java.io.File
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class CartRepositoryImplTest {
+
+    private lateinit var context: Context
+    private lateinit var database: CartDatabase
+    private lateinit var preferences: CartPreferences
+    private lateinit var local: CartLocalDataSource
+    private lateinit var remote: FakeCartRemoteDataSource
+    private lateinit var connectivity: MutableStateFlow<Boolean>
+    private lateinit var dispatcher: StandardTestDispatcher
+    private lateinit var scope: TestScope
+    private lateinit var repository: CartRepositoryImpl
+    private var now: Long = 0L
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        database = Room.inMemoryDatabaseBuilder(context, CartDatabase::class.java)
+            .allowMainThreadQueries()
+            .addTypeConverter(CartTypeConverters)
+            .build()
+        preferences = CartPreferences(context)
+        dispatcher = StandardTestDispatcher()
+        scope = TestScope(dispatcher)
+        local = CartLocalDataSource(database.cartDao(), preferences, dispatcher = dispatcher) { now }
+        remote = FakeCartRemoteDataSource()
+        connectivity = MutableStateFlow(false)
+        repository = CartRepositoryImpl(local, remote, connectivity, scope, dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        // Clean up preferences file between tests
+        val storeFile = File(context.filesDir, "datastore/cart_metadata.preferences_pb")
+        if (storeFile.exists()) storeFile.delete()
+    }
+
+    @Test
+    fun ttlEvictionRemovesExpiredItems() = scope.runTest {
+        val update = CartItemUpdate(
+            productId = "product-1",
+            title = "Laptop",
+            priceCents = 100_00,
+            currency = "usd",
+            quantity = 1,
+            variantDetails = listOf(CartVariantDetail("Color", "Space Gray"))
+        )
+        now = 0L
+        local.upsert(update, ttlOverride = 1_000L)
+        now = 5_000L
+        val evicted = local.evictExpired()
+        assertEquals(1, evicted)
+        val active = local.getActive()
+        assertTrue(active.isEmpty())
+    }
+
+    @Test
+    fun offlineOperationsAreQueued() = scope.runTest {
+        val variants = listOf(CartVariantDetail("Storage", "1TB"))
+        val update = CartItemUpdate(
+            productId = "prod-1",
+            title = "Phone",
+            priceCents = 80_00,
+            currency = "usd",
+            quantity = 2,
+            variantDetails = variants
+        )
+
+        repository.addOrUpdate(update)
+        advanceUntilIdle()
+
+        assertTrue(remote.upserted.isEmpty())
+        val pending = local.pendingOperations()
+        assertEquals(1, pending.size)
+        assertEquals(CartSyncOperation.ADD, pending.first().pendingOperation)
+
+        val cartItemId = buildCartItemId(update.productId, variants)
+        repository.remove(cartItemId, variants)
+        advanceUntilIdle()
+
+        val pendingAfterRemove = local.pendingOperations()
+        assertTrue(pendingAfterRemove.any { it.pendingOperation == CartSyncOperation.REMOVE })
+    }
+
+    @Test
+    fun loginFlushesPendingOperations() = scope.runTest {
+        val variants = listOf(CartVariantDetail("Edition", "Pro"))
+        val update = CartItemUpdate(
+            productId = "prod-2",
+            title = "Headphones",
+            priceCents = 50_00,
+            currency = "usd",
+            quantity = 1,
+            variantDetails = variants
+        )
+
+        repository.addOrUpdate(update)
+        advanceUntilIdle()
+        assertTrue(remote.upserted.isEmpty())
+
+        connectivity.value = true
+        repository.onLogin()
+        advanceUntilIdle()
+
+        assertEquals(1, remote.upserted.size)
+        val pending = local.pendingOperations()
+        assertTrue(pending.isEmpty())
+    }
+
+    private class FakeCartRemoteDataSource : CartRemoteDataSource {
+        val upserted = mutableListOf<CartRemoteItem>()
+        val removed = mutableListOf<String>()
+
+        override suspend fun fetchCart(): CartFetchResult = CartFetchResult(upserted.toList())
+
+        override suspend fun upsertItem(item: CartRemoteItem): CartRemoteItem {
+            upserted.removeAll { it.cartItemId == item.cartItemId }
+            upserted.add(item)
+            return item
+        }
+
+        override suspend fun removeItem(cartItemId: String) {
+            removed.add(cartItemId)
+            upserted.removeAll { it.cartItemId == cartItemId }
+        }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/app/MainActivity.kt
+++ b/app/src/main/java/com/techmarketplace/app/MainActivity.kt
@@ -50,6 +50,7 @@ import com.techmarketplace.presentation.auth.view.LoginScreen
 import com.techmarketplace.presentation.auth.view.RegisterScreen
 import com.techmarketplace.presentation.auth.viewmodel.LoginViewModel
 import com.techmarketplace.presentation.cart.view.MyCartScreen
+import com.techmarketplace.presentation.cart.viewmodel.CartViewModel
 import com.techmarketplace.presentation.home.view.AddProductRoute
 import com.techmarketplace.presentation.home.view.HomeRoute
 import com.techmarketplace.presentation.onboarding.view.WelcomeScreen
@@ -141,6 +142,8 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    val cartViewModel: CartViewModel = viewModel(factory = CartViewModel.factory(app))
+
                     NavHost(navController = nav, startDestination = "login") {
 
                         composable("welcome") {
@@ -156,6 +159,7 @@ class MainActivity : ComponentActivity() {
                                     authVM.login(email, pass) { ok: Boolean ->
                                         if (ok) {
                                             Toast.makeText(context, "Welcome!", Toast.LENGTH_SHORT).show()
+                                            cartViewModel.onLogin()
                                             // 👉 Ir DIRECTO al Home (sin LocationGate)
                                             nav.navigate(BottomItem.Home.route) {
                                                 popUpTo("login") { inclusive = true }
@@ -182,6 +186,7 @@ class MainActivity : ComponentActivity() {
                                     authVM.register(name, email, pass, campus) { ok: Boolean ->
                                         if (ok) {
                                             Toast.makeText(context, "Account created!", Toast.LENGTH_SHORT).show()
+                                            cartViewModel.onLogin()
                                             // 👉 También directo al Home
                                             nav.navigate(BottomItem.Home.route) {
                                                 popUpTo("login") { inclusive = true }
@@ -218,6 +223,7 @@ class MainActivity : ComponentActivity() {
                             val id = backStackEntry.arguments?.getString("id") ?: return@composable
                             ProductDetailRoute(
                                 listingId = id,
+                                cartViewModel = cartViewModel,
                                 onBack = { nav.popBackStack() }
                             )
                         }
@@ -238,6 +244,7 @@ class MainActivity : ComponentActivity() {
                         }
                         composable(BottomItem.Cart.route) {
                             MyCartScreen(
+                                viewModel = cartViewModel,
                                 onNavigateBottom = { navigateBottom(BottomItem.Home) }
                             )
                         }

--- a/app/src/main/java/com/techmarketplace/data/remote/ApiClient.kt
+++ b/app/src/main/java/com/techmarketplace/data/remote/ApiClient.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.techmarketplace.BuildConfig
 import com.techmarketplace.data.remote.api.AuthApi
+import com.techmarketplace.data.remote.api.CartApi
 import com.techmarketplace.data.remote.api.ImagesApi
 import com.techmarketplace.data.remote.api.ListingApi
 import com.techmarketplace.data.remote.api.OrdersApi
@@ -49,6 +50,7 @@ object ApiClient {
     fun ordersApi(): OrdersApi = retrofit.create()
     fun paymentsApi(): PaymentsApi = retrofit.create()
     fun priceSuggestionsApi(): PriceSuggestionsApi = retrofit.create()
+    fun cartApi(): CartApi = retrofit.create()
 
     /** Llamar una vez desde Application o Activity: ApiClient.init(applicationContext) */
     fun init(appContext: Context) {

--- a/app/src/main/java/com/techmarketplace/data/remote/api/CartApi.kt
+++ b/app/src/main/java/com/techmarketplace/data/remote/api/CartApi.kt
@@ -1,0 +1,53 @@
+package com.techmarketplace.data.remote.api
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface CartApi {
+    @GET("cart")
+    suspend fun getCart(): CartResponse
+
+    @POST("cart/items")
+    suspend fun upsertItem(@Body body: UpsertCartItemIn): CartItemDto
+
+    @DELETE("cart/items/{cart_item_id}")
+    suspend fun deleteItem(@Path("cart_item_id") cartItemId: String)
+}
+
+@Serializable
+data class CartResponse(
+    val items: List<CartItemDto> = emptyList(),
+    @SerialName("ttl_seconds") val ttlSeconds: Long? = null,
+    @SerialName("last_sync_epoch_millis") val lastSyncEpochMillis: Long? = null
+)
+
+@Serializable
+data class CartItemDto(
+    @SerialName("cart_item_id") val cartItemId: String,
+    @SerialName("product_id") val productId: String,
+    val title: String,
+    @SerialName("price_cents") val priceCents: Int,
+    val currency: String,
+    val quantity: Int,
+    @SerialName("variant_details") val variantDetails: List<CartVariantDetailDto> = emptyList(),
+    @SerialName("thumbnail_url") val thumbnailUrl: String? = null
+)
+
+@Serializable
+data class CartVariantDetailDto(
+    val name: String,
+    val value: String
+)
+
+@Serializable
+data class UpsertCartItemIn(
+    @SerialName("cart_item_id") val cartItemId: String? = null,
+    @SerialName("product_id") val productId: String,
+    val quantity: Int,
+    @SerialName("variant_details") val variantDetails: List<CartVariantDetailDto> = emptyList()
+)

--- a/app/src/main/java/com/techmarketplace/data/repository/cart/CartMappers.kt
+++ b/app/src/main/java/com/techmarketplace/data/repository/cart/CartMappers.kt
@@ -1,0 +1,56 @@
+package com.techmarketplace.data.repository.cart
+
+import com.techmarketplace.data.remote.api.CartRemoteItem
+import com.techmarketplace.data.storage.dao.CartItemEntity
+import com.techmarketplace.domain.cart.CartItem
+import com.techmarketplace.domain.cart.CartItemUpdate
+
+internal fun CartItemEntity.toDomain(): CartItem = CartItem(
+    id = cartItemId,
+    productId = productId,
+    title = title,
+    quantity = quantity,
+    priceCents = priceCents,
+    currency = currency,
+    variantDetails = variantDetails,
+    thumbnailUrl = thumbnailUrl,
+    lastModifiedEpochMillis = lastModifiedEpochMillis,
+    expiresAtEpochMillis = expiresAtEpochMillis,
+    pendingOperation = pendingOperation
+)
+
+internal fun CartItemEntity.toRemoteItem(): CartRemoteItem = CartRemoteItem(
+    cartItemId = cartItemId,
+    productId = productId,
+    title = title,
+    priceCents = priceCents,
+    currency = currency,
+    quantity = quantity,
+    variantDetails = variantDetails,
+    thumbnailUrl = thumbnailUrl
+)
+
+internal fun CartRemoteItem.toEntity(now: Long): CartItemEntity = CartItemEntity(
+    cartItemId = cartItemId,
+    productId = productId,
+    title = title,
+    priceCents = priceCents,
+    currency = currency,
+    quantity = quantity,
+    variantDetails = variantDetails,
+    thumbnailUrl = thumbnailUrl,
+    lastModifiedEpochMillis = now,
+    expiresAtEpochMillis = null,
+    pendingOperation = null,
+    pendingQuantity = null
+)
+
+internal fun CartRemoteItem.toUpdate(): CartItemUpdate = CartItemUpdate(
+    productId = productId,
+    title = title,
+    priceCents = priceCents,
+    currency = currency,
+    quantity = quantity,
+    variantDetails = variantDetails,
+    thumbnailUrl = thumbnailUrl
+)

--- a/app/src/main/java/com/techmarketplace/data/repository/cart/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/techmarketplace/data/repository/cart/CartRepositoryImpl.kt
@@ -1,0 +1,212 @@
+package com.techmarketplace.data.repository.cart
+
+import com.techmarketplace.data.remote.api.CartRemoteDataSource
+import com.techmarketplace.data.storage.cart.CartLocalDataSource
+import com.techmarketplace.data.storage.cart.CartViewport
+import com.techmarketplace.domain.cart.CartItemUpdate
+import com.techmarketplace.domain.cart.CartRepository
+import com.techmarketplace.domain.cart.CartState
+import com.techmarketplace.domain.cart.CartSyncOperation
+import com.techmarketplace.domain.cart.CartVariantDetail
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+class CartRepositoryImpl(
+    private val local: CartLocalDataSource,
+    private val remote: CartRemoteDataSource,
+    connectivityFlow: Flow<Boolean>,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : CartRepository {
+
+    private val _cartState = MutableStateFlow(CartState())
+    override val cartState: StateFlow<CartState> = _cartState
+
+    private val isOnline = MutableStateFlow(false)
+    private val lastError = AtomicReference<String?>(null)
+    private val syncMutex = Mutex()
+
+    init {
+        scope.launch { observeConnectivity(connectivityFlow) }
+        scope.launch { observeLocalChanges() }
+    }
+
+    private suspend fun observeConnectivity(connectivityFlow: Flow<Boolean>) {
+        connectivityFlow.distinctUntilChanged().collect { online ->
+            isOnline.value = online
+            if (online) {
+                flushPendingOperations()
+                refresh()
+            } else {
+                updateState { it.copy(isOffline = true) }
+            }
+        }
+    }
+
+    private suspend fun observeLocalChanges() {
+        combine(local.cartViewport, local.metadata, isOnline) { viewport, metadata, online ->
+            buildState(viewport, metadata.lastSyncEpochMillis, online)
+        }.collect { state ->
+            _cartState.value = state.copy(errorMessage = lastError.get())
+        }
+    }
+
+    private fun buildState(viewport: CartViewport, lastSync: Long?, online: Boolean): CartState {
+        val items = viewport.active.map { it.toDomain() }
+        val pending = viewport.active.count { it.pendingOperation != null }
+        return CartState(
+            items = items,
+            isOffline = !online,
+            hasExpiredItems = viewport.expiredCount > 0,
+            lastSyncEpochMillis = lastSync,
+            pendingOperationCount = pending,
+            errorMessage = lastError.get()
+        )
+    }
+
+    override suspend fun refresh() {
+        if (!isOnline.value) {
+            local.evictExpired()
+            return
+        }
+        runCatching {
+            val response = withContext(dispatcher) { remote.fetchCart() }
+            val ttl = response.ttlMillis
+            if (ttl != null) {
+                local.updateTtl(ttl)
+            }
+            val now = System.currentTimeMillis()
+            val entities = response.items.map { it.toEntity(now) }
+            local.replaceWithRemote(entities, ttl)
+            clearError()
+        }.onFailure { error ->
+            setError(error)
+        }
+    }
+
+    override suspend fun addOrUpdate(item: CartItemUpdate) {
+        val operation = resolveOperation(item)
+        val online = isOnline.value
+        val prepared = local.upsert(item, markPending = if (!online) operation else null)
+        if (!online) {
+            return
+        }
+
+        runCatching {
+            val response = withContext(dispatcher) { remote.upsertItem(prepared.toRemoteItem()) }
+            val update = response.toUpdate()
+            local.upsert(update, clearPending = true)
+            local.updateLastSync()
+            clearError()
+        }.onFailure { error ->
+            local.upsert(item, markPending = operation)
+            setError(error)
+        }
+    }
+
+    override suspend fun updateQuantity(itemId: String, quantity: Int) {
+        val existing = local.getItem(itemId) ?: return
+        val online = isOnline.value
+        val updated = local.updateQuantity(itemId, quantity, markPending = !online)
+        if (!online || updated == null) return
+
+        runCatching {
+            val response = withContext(dispatcher) { remote.upsertItem(updated.toRemoteItem()) }
+            val update = response.toUpdate()
+            local.upsert(update, clearPending = true)
+            local.updateLastSync()
+            clearError()
+        }.onFailure { error ->
+            local.updateQuantity(itemId, quantity, markPending = true)
+            setError(error)
+        }
+    }
+
+    override suspend fun remove(itemId: String, variantDetails: List<CartVariantDetail>) {
+        val existing = local.getItem(itemId) ?: return
+        local.removeById(itemId, markPending = true)
+        val online = isOnline.value
+        if (!online) return
+
+        val pendingEntity = local.getItem(itemId) ?: existing.copy(
+            quantity = 0,
+            pendingOperation = CartSyncOperation.REMOVE,
+            pendingQuantity = existing.quantity
+        )
+
+        runCatching {
+            withContext(dispatcher) { remote.removeItem(itemId) }
+            local.markSynced(pendingEntity)
+            local.updateLastSync()
+            clearError()
+        }.onFailure { error ->
+            setError(error)
+        }
+    }
+
+    override suspend fun onLogin() {
+        if (isOnline.value) {
+            flushPendingOperations()
+            refresh()
+        }
+    }
+
+    private suspend fun flushPendingOperations() {
+        syncMutex.withLock {
+            val pending = local.pendingOperations()
+            if (pending.isEmpty()) return
+            for (entity in pending) {
+                try {
+                    when (entity.pendingOperation) {
+                        CartSyncOperation.REMOVE -> {
+                            remote.removeItem(entity.cartItemId)
+                            local.markSynced(entity)
+                        }
+                        CartSyncOperation.ADD, CartSyncOperation.UPDATE -> {
+                            val response = remote.upsertItem(entity.toRemoteItem())
+                            local.upsert(response.toUpdate(), clearPending = true)
+                        }
+                        null -> Unit
+                    }
+                } catch (error: Exception) {
+                    setError(error)
+                    return
+                }
+            }
+            local.updateLastSync()
+            clearError()
+        }
+    }
+
+    private suspend fun resolveOperation(item: CartItemUpdate): CartSyncOperation {
+        val id = CartLocalDataSource.buildCartItemId(item.productId, item.variantDetails)
+        val existing = local.getItem(id)
+        return if (existing == null) CartSyncOperation.ADD else CartSyncOperation.UPDATE
+    }
+
+    private fun updateState(transform: (CartState) -> CartState) {
+        _cartState.value = transform(_cartState.value)
+    }
+
+    private fun clearError() {
+        lastError.set(null)
+        updateState { it.copy(errorMessage = null) }
+    }
+
+    private fun setError(error: Throwable) {
+        lastError.set(error.message ?: error.javaClass.simpleName)
+        updateState { it.copy(errorMessage = lastError.get()) }
+    }
+
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/CartPreferences.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/CartPreferences.kt
@@ -1,0 +1,53 @@
+package com.techmarketplace.data.storage
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val DEFAULT_TTL_MILLIS = 30L * 60L * 1000L
+
+data class CartMetadata(
+    val ttlMillis: Long = DEFAULT_TTL_MILLIS,
+    val lastSyncEpochMillis: Long? = null
+)
+
+private val Context.cartMetadataStore: DataStore<Preferences> by preferencesDataStore(name = "cart_metadata")
+
+class CartPreferences internal constructor(
+    private val dataStore: DataStore<Preferences>
+) {
+
+    constructor(context: Context) : this(context.applicationContext.cartMetadataStore)
+
+    private val ttlKey = longPreferencesKey("ttl_millis")
+    private val lastSyncKey = longPreferencesKey("last_sync")
+
+    val metadata: Flow<CartMetadata> = dataStore.data.map { prefs ->
+        val ttl = prefs[ttlKey] ?: DEFAULT_TTL_MILLIS
+        val lastSync = prefs[lastSyncKey]
+        CartMetadata(ttlMillis = ttl, lastSyncEpochMillis = lastSync)
+    }
+
+    suspend fun updateTtl(ttlMillis: Long) {
+        dataStore.edit { prefs ->
+            prefs[ttlKey] = ttlMillis
+        }
+    }
+
+    suspend fun updateLastSync(epochMillis: Long) {
+        dataStore.edit { prefs ->
+            prefs[lastSyncKey] = epochMillis
+        }
+    }
+
+    suspend fun clearLastSync() {
+        dataStore.edit { prefs ->
+            prefs.remove(lastSyncKey)
+        }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/cart/CartLocalDataSource.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/cart/CartLocalDataSource.kt
@@ -1,0 +1,201 @@
+package com.techmarketplace.data.storage.cart
+
+import com.techmarketplace.data.storage.CartMetadata
+import com.techmarketplace.data.storage.CartPreferences
+import com.techmarketplace.data.storage.dao.CartDao
+import com.techmarketplace.data.storage.dao.CartItemEntity
+import com.techmarketplace.domain.cart.CartItemUpdate
+import com.techmarketplace.domain.cart.CartSyncOperation
+import com.techmarketplace.domain.cart.CartVariantDetail
+import java.util.Locale
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+data class CartViewport(
+    val active: List<CartItemEntity>,
+    val expiredCount: Int
+)
+
+class CartLocalDataSource(
+    private val cartDao: CartDao,
+    private val preferences: CartPreferences,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val nowProvider: () -> Long = { System.currentTimeMillis() }
+) {
+
+    val cartViewport: Flow<CartViewport> = cartDao.observeAll()
+        .map { items ->
+            val now = nowProvider()
+            val (active, expired) = items.partition { !it.isExpired(now) }
+            CartViewport(active = active, expiredCount = expired.size)
+        }
+
+    val metadata: Flow<CartMetadata> = preferences.metadata
+
+    suspend fun updateTtl(ttlMillis: Long) = withContext(dispatcher) {
+        preferences.updateTtl(ttlMillis)
+    }
+
+    suspend fun getActive(): List<CartItemEntity> = withContext(dispatcher) {
+        evictExpiredInternal()
+        cartDao.getActive(nowProvider())
+    }
+
+    suspend fun upsert(
+        update: CartItemUpdate,
+        markPending: CartSyncOperation? = null,
+        ttlOverride: Long? = null,
+        clearPending: Boolean = false
+    ): CartItemEntity =
+        withContext(dispatcher) {
+            val id = buildCartItemId(update.productId, update.variantDetails)
+            val now = nowProvider()
+            val current = cartDao.getById(id)
+            val ttl = ttlOverride ?: preferences.metadata.first().ttlMillis
+            val expiresAt = ttl.takeIf { it > 0L }?.let { now + it }
+            val pendingOp = when {
+                clearPending -> null
+                markPending != null -> markPending
+                else -> current?.pendingOperation
+            }
+            val pendingQty = when {
+                clearPending -> null
+                markPending == CartSyncOperation.REMOVE -> current?.quantity ?: update.quantity
+                markPending != null -> update.quantity
+                else -> current?.pendingQuantity
+            }
+            val entity = CartItemEntity(
+                cartItemId = id,
+                productId = update.productId,
+                title = update.title,
+                priceCents = update.priceCents,
+                currency = update.currency.uppercase(Locale.US),
+                quantity = update.quantity,
+                variantDetails = update.variantDetails,
+                thumbnailUrl = update.thumbnailUrl,
+                lastModifiedEpochMillis = now,
+                expiresAtEpochMillis = expiresAt,
+                pendingOperation = pendingOp,
+                pendingQuantity = pendingQty
+            )
+            cartDao.upsert(entity)
+            entity
+        }
+
+    suspend fun remove(productId: String, variantDetails: List<CartVariantDetail>, markPending: Boolean): Boolean =
+        withContext(dispatcher) {
+            val id = buildCartItemId(productId, variantDetails)
+            val existing = cartDao.getById(id) ?: return@withContext false
+            handleRemoval(existing, markPending)
+            true
+        }
+
+    suspend fun removeById(cartItemId: String, markPending: Boolean): Boolean = withContext(dispatcher) {
+        val existing = cartDao.getById(cartItemId) ?: return@withContext false
+        handleRemoval(existing, markPending)
+        true
+    }
+
+    private suspend fun handleRemoval(existing: CartItemEntity, markPending: Boolean) {
+            val now = nowProvider()
+            if (markPending) {
+                val pendingQuantity = existing.quantity
+                val updated = existing.copy(
+                    quantity = 0,
+                    lastModifiedEpochMillis = now,
+                    pendingOperation = CartSyncOperation.REMOVE,
+                    pendingQuantity = pendingQuantity
+                )
+                cartDao.upsert(updated)
+            } else {
+                cartDao.delete(existing.cartItemId)
+            }
+    }
+
+    suspend fun updateQuantity(cartItemId: String, quantity: Int, markPending: Boolean): CartItemEntity? =
+        withContext(dispatcher) {
+            val existing = cartDao.getById(cartItemId) ?: return@withContext null
+            val now = nowProvider()
+            val pendingOp = when {
+                markPending -> CartSyncOperation.UPDATE
+                else -> existing.pendingOperation
+            }
+            val pendingQty = when {
+                markPending -> quantity
+                else -> existing.pendingQuantity
+            }
+            val updated = existing.copy(
+                quantity = quantity,
+                lastModifiedEpochMillis = now,
+                pendingOperation = pendingOp,
+                pendingQuantity = pendingQty
+            )
+            cartDao.upsert(updated)
+            updated
+        }
+
+    suspend fun replaceWithRemote(items: List<CartItemEntity>, ttlOverride: Long? = null) = withContext(dispatcher) {
+        val ttl = ttlOverride ?: preferences.metadata.first().ttlMillis
+        val now = nowProvider()
+        val updated = items.map { entity ->
+            val expiresAt = ttl.takeIf { it > 0L }?.let { now + it }
+            entity.copy(
+                lastModifiedEpochMillis = now,
+                expiresAtEpochMillis = expiresAt,
+                pendingOperation = null,
+                pendingQuantity = null
+            )
+        }
+        cartDao.replaceAll(updated)
+        preferences.updateLastSync(now)
+    }
+
+    suspend fun pendingOperations(): List<CartItemEntity> = withContext(dispatcher) {
+        cartDao.getPending()
+    }
+
+    suspend fun getItem(cartItemId: String): CartItemEntity? = withContext(dispatcher) {
+        cartDao.getById(cartItemId)
+    }
+
+    suspend fun markSynced(vararg items: CartItemEntity) = withContext(dispatcher) {
+        val now = nowProvider()
+        val idsToClear = mutableListOf<String>()
+        items.forEach { entity ->
+            when (entity.pendingOperation) {
+                CartSyncOperation.REMOVE -> cartDao.delete(entity.cartItemId)
+                else -> idsToClear.add(entity.cartItemId)
+            }
+        }
+        if (idsToClear.isNotEmpty()) {
+            cartDao.clearPending(idsToClear, now)
+        }
+    }
+
+    suspend fun clearPending(cartItemId: String) = withContext(dispatcher) {
+        cartDao.clearPending(listOf(cartItemId), nowProvider())
+    }
+
+    suspend fun evictExpired(): Int = withContext(dispatcher) { evictExpiredInternal() }
+
+    suspend fun updateLastSync() = withContext(dispatcher) {
+        preferences.updateLastSync(nowProvider())
+    }
+
+    private suspend fun evictExpiredInternal(): Int {
+        val now = nowProvider()
+        return cartDao.deleteExpired(now)
+    }
+
+    companion object {
+        fun buildCartItemId(productId: String, variantDetails: List<CartVariantDetail>): String {
+            if (variantDetails.isEmpty()) return productId
+            val variantKey = variantDetails.joinToString(separator = "|") { "${it.name}:${it.value}" }
+            return "$productId@$variantKey"
+        }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/CartDao.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/CartDao.kt
@@ -1,0 +1,54 @@
+package com.techmarketplace.data.storage.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CartDao {
+
+    @Query("SELECT * FROM cart_items ORDER BY lastModifiedEpochMillis DESC")
+    fun observeAll(): Flow<List<CartItemEntity>>
+
+    @Query("SELECT * FROM cart_items WHERE cartItemId = :id")
+    suspend fun getById(id: String): CartItemEntity?
+
+    @Query("SELECT * FROM cart_items WHERE expiresAtEpochMillis IS NULL OR expiresAtEpochMillis > :now")
+    suspend fun getActive(now: Long): List<CartItemEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(item: CartItemEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(items: List<CartItemEntity>)
+
+    @Query("DELETE FROM cart_items WHERE cartItemId = :id")
+    suspend fun delete(id: String)
+
+    @Query("DELETE FROM cart_items WHERE expiresAtEpochMillis IS NOT NULL AND expiresAtEpochMillis <= :now")
+    suspend fun deleteExpired(now: Long): Int
+
+    @Query("UPDATE cart_items SET quantity = :quantity, lastModifiedEpochMillis = :lastModified WHERE cartItemId = :id")
+    suspend fun updateQuantity(id: String, quantity: Int, lastModified: Long)
+
+    @Query("UPDATE cart_items SET pendingOperation = :operation, pendingQuantity = :quantity, lastModifiedEpochMillis = :lastModified WHERE cartItemId = :id")
+    suspend fun markPending(id: String, operation: String?, quantity: Int?, lastModified: Long)
+
+    @Query("UPDATE cart_items SET pendingOperation = NULL, pendingQuantity = NULL, lastModifiedEpochMillis = :lastModified WHERE cartItemId IN (:ids)")
+    suspend fun clearPending(ids: List<String>, lastModified: Long)
+
+    @Query("SELECT * FROM cart_items WHERE pendingOperation IS NOT NULL ORDER BY lastModifiedEpochMillis ASC")
+    suspend fun getPending(): List<CartItemEntity>
+
+    @Transaction
+    suspend fun replaceAll(items: List<CartItemEntity>) {
+        deleteAll()
+        upsert(items)
+    }
+
+    @Query("DELETE FROM cart_items")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/CartDatabase.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/CartDatabase.kt
@@ -1,0 +1,35 @@
+package com.techmarketplace.data.storage.dao
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(
+    entities = [CartItemEntity::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(CartTypeConverters::class)
+abstract class CartDatabase : RoomDatabase() {
+    abstract fun cartDao(): CartDao
+}
+
+object CartDatabaseProvider {
+
+    @Volatile
+    private var instance: CartDatabase? = null
+
+    fun get(context: Context): CartDatabase {
+        return instance ?: synchronized(this) {
+            instance ?: build(context.applicationContext).also { instance = it }
+        }
+    }
+
+    private fun build(context: Context): CartDatabase {
+        return Room.databaseBuilder(context, CartDatabase::class.java, "cart.db")
+            .fallbackToDestructiveMigration()
+            .build()
+    }
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/CartItemEntity.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/CartItemEntity.kt
@@ -1,0 +1,24 @@
+package com.techmarketplace.data.storage.dao
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.techmarketplace.domain.cart.CartSyncOperation
+import com.techmarketplace.domain.cart.CartVariantDetail
+
+@Entity(tableName = "cart_items")
+data class CartItemEntity(
+    @PrimaryKey val cartItemId: String,
+    val productId: String,
+    val title: String,
+    val priceCents: Int,
+    val currency: String,
+    val quantity: Int,
+    val variantDetails: List<CartVariantDetail> = emptyList(),
+    val thumbnailUrl: String? = null,
+    val lastModifiedEpochMillis: Long,
+    val expiresAtEpochMillis: Long? = null,
+    val pendingOperation: CartSyncOperation? = null,
+    val pendingQuantity: Int? = null
+) {
+    fun isExpired(now: Long): Boolean = expiresAtEpochMillis?.let { it <= now } ?: false
+}

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/CartTypeConverters.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/CartTypeConverters.kt
@@ -1,0 +1,77 @@
+package com.techmarketplace.data.storage.dao
+
+import androidx.room.TypeConverter
+import com.techmarketplace.domain.cart.CartSyncOperation
+import com.techmarketplace.domain.cart.CartVariantDetail
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private const val AES_TRANSFORMATION = "AES/GCM/NoPadding"
+private const val AES_KEY_ALGORITHM = "AES"
+private const val AES_KEY_BYTES = 16
+
+object CartTypeConverters {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val variantSerializer = ListSerializer(CartVariantDetail.serializer())
+
+    private val secretKey by lazy {
+        val digest = MessageDigest.getInstance("SHA-256").digest("techmarketplace-cart-key".toByteArray(StandardCharsets.UTF_8))
+        SecretKeySpec(digest.copyOf(AES_KEY_BYTES), AES_KEY_ALGORITHM)
+    }
+
+    private val secureRandom = SecureRandom()
+
+    @TypeConverter
+    fun fromVariantDetails(details: List<CartVariantDetail>?): String {
+        if (details.isNullOrEmpty()) return ""
+        val plain = json.encodeToString(variantSerializer, details)
+        return encrypt(plain)
+    }
+
+    @TypeConverter
+    fun toVariantDetails(payload: String?): List<CartVariantDetail> {
+        if (payload.isNullOrEmpty()) return emptyList()
+        val decoded = runCatching { decrypt(payload) }.getOrElse { payload }
+        return runCatching { json.decodeFromString(variantSerializer, decoded) }.getOrElse { emptyList() }
+    }
+
+    @TypeConverter
+    fun fromPendingOperation(operation: CartSyncOperation?): String? = operation?.name
+
+    @TypeConverter
+    fun toPendingOperation(value: String?): CartSyncOperation? = value?.let { runCatching { CartSyncOperation.valueOf(it) }.getOrNull() }
+
+    private fun encrypt(plain: String): String {
+        return runCatching {
+            val cipher = Cipher.getInstance(AES_TRANSFORMATION)
+            val iv = ByteArray(12).also { secureRandom.nextBytes(it) }
+            val spec = GCMParameterSpec(128, iv)
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, spec)
+            val ciphertext = cipher.doFinal(plain.toByteArray(StandardCharsets.UTF_8))
+            val payload = iv + ciphertext
+            Base64.getEncoder().encodeToString(payload)
+        }.getOrElse { plain }
+    }
+
+    private fun decrypt(encoded: String): String {
+        return runCatching {
+            val payload = Base64.getDecoder().decode(encoded)
+            val iv = payload.copyOfRange(0, 12)
+            val ciphertext = payload.copyOfRange(12, payload.size)
+            val cipher = Cipher.getInstance(AES_TRANSFORMATION)
+            val spec = GCMParameterSpec(128, iv)
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
+            val plainBytes = cipher.doFinal(ciphertext)
+            String(plainBytes, StandardCharsets.UTF_8)
+        }.getOrElse { encoded }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/data/work/CartValidationWorker.kt
+++ b/app/src/main/java/com/techmarketplace/data/work/CartValidationWorker.kt
@@ -1,0 +1,65 @@
+package com.techmarketplace.data.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.techmarketplace.core.connectivity.ConnectivityObserver
+import com.techmarketplace.data.remote.api.CartRemoteDataSource
+import com.techmarketplace.data.remote.api.NoOpCartRemoteDataSource
+import com.techmarketplace.data.repository.cart.toEntity
+import com.techmarketplace.data.storage.CartPreferences
+import com.techmarketplace.data.storage.cart.CartLocalDataSource
+import com.techmarketplace.data.storage.dao.CartDatabaseProvider
+import java.util.concurrent.TimeUnit
+
+class CartValidationWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val context = applicationContext
+        if (!ConnectivityObserver.isOnlineNow(context)) {
+            return Result.retry()
+        }
+
+        val database = CartDatabaseProvider.get(context)
+        val dao = database.cartDao()
+        val local = CartLocalDataSource(dao, CartPreferences(context))
+        val remote = CartWorkerDependencies.remoteDataSource
+
+        return runCatching {
+            val response = remote.fetchCart()
+            val ttl = response.ttlMillis
+            if (ttl != null) {
+                local.updateTtl(ttl)
+            }
+            val now = System.currentTimeMillis()
+            val entities = response.items.map { it.toEntity(now) }
+            local.replaceWithRemote(entities, ttl)
+            Result.success()
+        }.getOrElse {
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val UNIQUE_NAME = "cart-validation"
+
+        fun schedule(context: Context, repeatHours: Long = 6L) {
+            val work = PeriodicWorkRequestBuilder<CartValidationWorker>(repeatHours, TimeUnit.HOURS)
+                .setInitialDelay(15, TimeUnit.MINUTES)
+                .build()
+            WorkManager.getInstance(context.applicationContext)
+                .enqueueUniquePeriodicWork(UNIQUE_NAME, ExistingPeriodicWorkPolicy.UPDATE, work)
+        }
+    }
+}
+
+object CartWorkerDependencies {
+    @Volatile
+    var remoteDataSource: CartRemoteDataSource = NoOpCartRemoteDataSource()
+}

--- a/app/src/main/java/com/techmarketplace/domain/cart/CartModels.kt
+++ b/app/src/main/java/com/techmarketplace/domain/cart/CartModels.kt
@@ -1,0 +1,50 @@
+package com.techmarketplace.domain.cart
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CartVariantDetail(
+    val name: String,
+    val value: String
+)
+
+enum class CartSyncOperation {
+    ADD,
+    UPDATE,
+    REMOVE
+}
+
+data class CartItem(
+    val id: String,
+    val productId: String,
+    val title: String,
+    val quantity: Int,
+    val priceCents: Int,
+    val currency: String,
+    val variantDetails: List<CartVariantDetail> = emptyList(),
+    val thumbnailUrl: String? = null,
+    val lastModifiedEpochMillis: Long,
+    val expiresAtEpochMillis: Long? = null,
+    val pendingOperation: CartSyncOperation? = null
+) {
+    val totalPriceCents: Int get() = priceCents * quantity
+}
+
+data class CartState(
+    val items: List<CartItem> = emptyList(),
+    val isOffline: Boolean = false,
+    val hasExpiredItems: Boolean = false,
+    val lastSyncEpochMillis: Long? = null,
+    val pendingOperationCount: Int = 0,
+    val errorMessage: String? = null
+)
+
+data class CartItemUpdate(
+    val productId: String,
+    val title: String,
+    val priceCents: Int,
+    val currency: String,
+    val quantity: Int,
+    val variantDetails: List<CartVariantDetail> = emptyList(),
+    val thumbnailUrl: String? = null
+)

--- a/app/src/main/java/com/techmarketplace/domain/cart/CartRepository.kt
+++ b/app/src/main/java/com/techmarketplace/domain/cart/CartRepository.kt
@@ -1,0 +1,17 @@
+package com.techmarketplace.domain.cart
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface CartRepository {
+    val cartState: StateFlow<CartState>
+
+    suspend fun refresh()
+
+    suspend fun addOrUpdate(item: CartItemUpdate)
+
+    suspend fun updateQuantity(itemId: String, quantity: Int)
+
+    suspend fun remove(itemId: String, variantDetails: List<CartVariantDetail>)
+
+    suspend fun onLogin()
+}

--- a/app/src/main/java/com/techmarketplace/presentation/cart/view/MyCartScreen.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/cart/view/MyCartScreen.kt
@@ -1,69 +1,103 @@
 package com.techmarketplace.presentation.cart.view
 
+import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.techmarketplace.core.designsystem.GreenDark
 import com.techmarketplace.core.ui.BottomItem
 import com.techmarketplace.core.ui.GreenScaffold
+import com.techmarketplace.domain.cart.CartItem
+import com.techmarketplace.domain.cart.CartState
+import com.techmarketplace.presentation.cart.viewmodel.CartViewModel
+import java.text.DateFormat
+import java.util.Locale
 
 @Composable
-fun MyCartScreen(onNavigateBottom: (BottomItem) -> Unit) {
-    val items = remember { List(8) { CartItem("Logitech GT12", "Mouse Wireless", 345) } }
-    val qty = remember { mutableStateListOf(*IntArray(items.size) { 1 }.toTypedArray()) }
-    val total by remember { derivedStateOf { items.indices.sumOf { items[it].price * qty[it] } } }
+fun MyCartScreen(
+    viewModel: CartViewModel,
+    onNavigateBottom: (BottomItem) -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.refresh()
+    }
+
+    LaunchedEffect(state.errorMessage) {
+        state.errorMessage?.let { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val totalCents = state.items.sumOf { it.totalPriceCents }
+    val totalCurrency = state.items.firstOrNull()?.currency ?: "COP"
 
     GreenScaffold(selected = BottomItem.Cart, onNavigateBottom = onNavigateBottom) {
-        Column(Modifier.fillMaxSize()) {
-            Spacer(Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
-
-            // Header
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text("My Cart", color = GreenDark, fontSize = 32.sp, fontWeight = FontWeight.SemiBold)
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    RoundIcon(Icons.Outlined.Search)
-                    RoundIconBell()
+        CartContent(
+            state = state,
+            onRefresh = { viewModel.refresh() },
+            onIncrement = { item -> viewModel.updateQuantity(item.id, item.quantity + 1) },
+            onDecrement = { item ->
+                if (item.quantity > 1) {
+                    viewModel.updateQuantity(item.id, item.quantity - 1)
+                } else {
+                    viewModel.remove(item.id, item.variantDetails)
                 }
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                contentPadding = PaddingValues(bottom = 132.dp)
-            ) {
-                itemsIndexed(items) { index, it ->
-                    CartRow(
-                        item = it,
-                        quantity = qty[index],
-                        onPlus = { qty[index] = qty[index] + 1 },
-                        onMinus = { qty[index] = maxOf(0, qty[index] - 1) }
-                    )
-                }
-            }
-        }
+            },
+            onRemove = { item -> viewModel.remove(item.id, item.variantDetails) }
+        )
 
         CheckoutPanel(
-            total = total,
-            onCheckout = { /* TODO */ },
+            totalLabel = formatPrice(totalCents, totalCurrency),
+            isOffline = state.isOffline,
+            pendingOperations = state.pendingOperationCount,
+            onCheckout = {
+                Toast.makeText(context, "Checkout coming soon", Toast.LENGTH_SHORT).show()
+            },
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 8.dp)
@@ -71,16 +105,130 @@ fun MyCartScreen(onNavigateBottom: (BottomItem) -> Unit) {
     }
 }
 
-/* ---------------- helpers UI ---------------- */
+@Composable
+private fun BoxScope.CartContent(
+    state: CartState,
+    onRefresh: () -> Unit,
+    onIncrement: (CartItem) -> Unit,
+    onDecrement: (CartItem) -> Unit,
+    onRemove: (CartItem) -> Unit
+) {
+    Column(Modifier.fillMaxSize()) {
+        Spacer(Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
 
-private data class CartItem(val title: String, val subtitle: String, val price: Int)
+        Header(onRefresh = onRefresh)
+
+        if (state.isOffline) {
+            StatusPill(text = "Offline – changes will sync later", color = Color(0xFFFFC107))
+        }
+
+        if (state.pendingOperationCount > 0) {
+            StatusPill(
+                text = "Pending sync: ${state.pendingOperationCount}",
+                color = Color(0xFF80CBC4)
+            )
+        }
+
+        if (state.hasExpiredItems) {
+            StatusPill(text = "Some items expired and were removed", color = Color(0xFFFFAB91))
+        }
+
+        state.lastSyncEpochMillis?.let { lastSync ->
+            val formatted = remember(lastSync) {
+                DateFormat.getDateTimeInstance().format(java.util.Date(lastSync))
+            }
+            Text(
+                text = "Last sync: $formatted",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFF607D8B),
+                modifier = Modifier.padding(top = 12.dp)
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        if (state.items.isEmpty()) {
+            EmptyState()
+        } else {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(bottom = 132.dp)
+            ) {
+                items(items = state.items, key = { it.id }) { item ->
+                    CartRow(
+                        item = item,
+                        onPlus = { onIncrement(item) },
+                        onMinus = { onDecrement(item) },
+                        onRemove = { onRemove(item) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Header(onRefresh: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text("My Cart", color = GreenDark, fontSize = 32.sp, fontWeight = FontWeight.SemiBold)
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            RoundIcon(Icons.Outlined.Search)
+            IconButton(onClick = onRefresh) {
+                Icon(Icons.Outlined.Refresh, contentDescription = "Refresh", tint = GreenDark)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Your cart is empty", color = GreenDark, fontWeight = FontWeight.SemiBold, fontSize = 18.sp)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "Browse listings and add items to start your order.",
+            color = Color(0xFF607D8B),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun StatusPill(text: String, color: Color) {
+    Surface(
+        color = color.copy(alpha = 0.16f),
+        contentColor = color,
+        shape = RoundedCornerShape(50),
+        border = BorderStroke(1.dp, color.copy(alpha = 0.32f)),
+        modifier = Modifier
+            .padding(top = 12.dp)
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
 
 @Composable
 private fun CartRow(
     item: CartItem,
-    quantity: Int,
     onPlus: () -> Unit,
-    onMinus: () -> Unit
+    onMinus: () -> Unit,
+    onRemove: () -> Unit
 ) {
     Surface(
         shape = RoundedCornerShape(20.dp),
@@ -89,31 +237,59 @@ private fun CartRow(
         tonalElevation = 0.dp,
         border = DividerDefaults.color.copy(alpha = 0.15f).let { BorderStroke(1.dp, it) }
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Surface(
-                modifier = Modifier
-                    .size(64.dp)
-                    .clip(RoundedCornerShape(12.dp)),
-                color = Color(0xFF1F1F1F)
-            ) {}
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                    color = Color(0xFF1F1F1F)
+                ) {}
 
-            Column(modifier = Modifier.weight(1f)) {
-                Text(item.title, color = GreenDark, fontWeight = FontWeight.SemiBold)
-                Text(item.subtitle, color = Color(0xFF9AA3AB), fontSize = 12.sp)
-                Spacer(Modifier.height(6.dp))
-                Text("$${item.price}", color = GreenDark, fontWeight = FontWeight.SemiBold)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(item.title, color = GreenDark, fontWeight = FontWeight.SemiBold)
+                    if (item.variantDetails.isNotEmpty()) {
+                        Text(
+                            text = item.variantDetails.joinToString { "${it.name}: ${it.value}" },
+                            color = Color(0xFF9AA3AB),
+                            fontSize = 12.sp
+                        )
+                    }
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        formatPrice(item.priceCents, item.currency),
+                        color = GreenDark,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    if (item.pendingOperation != null) {
+                        Text(
+                            text = "Pending ${item.pendingOperation.name.lowercase(Locale.getDefault())}",
+                            color = Color(0xFF6B7783),
+                            fontSize = 12.sp
+                        )
+                    }
+                }
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    CircleAction("+", filled = true, onClick = onPlus)
+                    Text("${item.quantity}", color = GreenDark, fontWeight = FontWeight.SemiBold)
+                    CircleAction("−", filled = false, onClick = onMinus)
+                }
             }
 
-            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                CircleAction("+", filled = true, onClick = onPlus)
-                Text("$quantity", color = GreenDark, fontWeight = FontWeight.SemiBold)
-                CircleAction("−", filled = false, onClick = onMinus)
+            TextButton(onClick = onRemove) {
+                Text("Remove", color = Color(0xFFB00020))
             }
         }
     }
@@ -129,7 +305,13 @@ private fun CircleAction(text: String, filled: Boolean, onClick: () -> Unit) {
 }
 
 @Composable
-private fun CheckoutPanel(total: Int, onCheckout: () -> Unit, modifier: Modifier = Modifier) {
+private fun CheckoutPanel(
+    totalLabel: String,
+    isOffline: Boolean,
+    pendingOperations: Int,
+    onCheckout: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Surface(
         modifier = modifier.fillMaxWidth(),
         color = Color(0xFFF2F2F4),
@@ -142,18 +324,40 @@ private fun CheckoutPanel(total: Int, onCheckout: () -> Unit, modifier: Modifier
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text("Total", color = GreenDark.copy(alpha = 0.8f), fontWeight = FontWeight.SemiBold)
-                Text("$${total}", color = GreenDark, fontWeight = FontWeight.SemiBold)
+                Text(totalLabel, color = GreenDark, fontWeight = FontWeight.SemiBold)
+            }
+            if (pendingOperations > 0) {
+                Text(
+                    text = "Waiting to sync $pendingOperations change(s)",
+                    color = Color(0xFF6B7783),
+                    fontSize = 12.sp,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
             }
             Spacer(Modifier.height(10.dp))
             Button(
                 onClick = onCheckout,
+                enabled = pendingOperations == 0 && !isOffline,
                 shape = RoundedCornerShape(28.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = GreenDark, contentColor = Color.White),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = GreenDark,
+                    contentColor = Color.White,
+                    disabledContainerColor = Color(0xFF9AA3AB),
+                    disabledContentColor = Color.White
+                ),
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(54.dp)
             ) {
                 Text("Checkout", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+            }
+            if (isOffline) {
+                Text(
+                    text = "Reconnect to place your order.",
+                    color = Color(0xFFB00020),
+                    fontSize = 12.sp,
+                    modifier = Modifier.padding(top = 6.dp)
+                )
             }
         }
     }
@@ -169,8 +373,15 @@ private fun RoundIcon(icon: androidx.compose.ui.graphics.vector.ImageVector) {
 @Composable
 private fun RoundIconBell() {
     Surface(color = Color(0xFFF5F5F5), shape = CircleShape) {
-        Box(Modifier.size(40.dp)) // placeholder campana
+        Box(Modifier.size(40.dp))
     }
+}
+
+private fun formatPrice(priceCents: Int, currency: String): String {
+    val amount = priceCents.toDouble() / 100.0
+    val locale = Locale.getDefault()
+    val formatted = String.format(locale, "%,.2f", amount)
+    return "${currency.uppercase(locale)} $formatted"
 }
 
 

--- a/app/src/main/java/com/techmarketplace/presentation/cart/viewmodel/CartViewModel.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/cart/viewmodel/CartViewModel.kt
@@ -1,0 +1,87 @@
+package com.techmarketplace.presentation.cart.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.techmarketplace.core.connectivity.ConnectivityObserver
+import com.techmarketplace.data.remote.ApiClient
+import com.techmarketplace.data.remote.api.CartRemoteDataSource
+import com.techmarketplace.data.remote.api.NoOpCartRemoteDataSource
+import com.techmarketplace.data.remote.api.RetrofitCartRemoteDataSource
+import com.techmarketplace.data.repository.cart.CartRepositoryImpl
+import com.techmarketplace.data.storage.CartPreferences
+import com.techmarketplace.data.storage.cart.CartLocalDataSource
+import com.techmarketplace.data.storage.dao.CartDatabaseProvider
+import com.techmarketplace.data.work.CartValidationWorker
+import com.techmarketplace.data.work.CartWorkerDependencies
+import com.techmarketplace.domain.cart.CartItemUpdate
+import com.techmarketplace.domain.cart.CartState
+import com.techmarketplace.domain.cart.CartVariantDetail
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+class CartViewModel(
+    app: Application,
+    private val localDataSource: CartLocalDataSource,
+    private val remoteDataSource: CartRemoteDataSource,
+    private val connectivityFlow: Flow<Boolean>
+) : AndroidViewModel(app) {
+
+    private val repository = CartRepositoryImpl(localDataSource, remoteDataSource, connectivityFlow, viewModelScope)
+
+    val state: StateFlow<CartState> = repository.cartState
+
+    init {
+        CartWorkerDependencies.remoteDataSource = remoteDataSource
+        viewModelScope.launch {
+            connectivityFlow.distinctUntilChanged().collect { online ->
+                if (online) {
+                    repository.refresh()
+                    CartValidationWorker.schedule(app)
+                }
+            }
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch { repository.refresh() }
+    }
+
+    fun addOrUpdate(update: CartItemUpdate) {
+        viewModelScope.launch { repository.addOrUpdate(update) }
+    }
+
+    fun updateQuantity(itemId: String, quantity: Int) {
+        viewModelScope.launch { repository.updateQuantity(itemId, quantity) }
+    }
+
+    fun remove(itemId: String, variantDetails: List<CartVariantDetail>) {
+        viewModelScope.launch { repository.remove(itemId, variantDetails) }
+    }
+
+    fun onLogin() {
+        viewModelScope.launch { repository.onLogin() }
+    }
+
+    companion object {
+        fun factory(app: Application): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val database = CartDatabaseProvider.get(app)
+                val preferences = CartPreferences(app)
+                val local = CartLocalDataSource(database.cartDao(), preferences)
+                val remote: CartRemoteDataSource = try {
+                    RetrofitCartRemoteDataSource(ApiClient.cartApi())
+                } catch (_: IllegalStateException) {
+                    NoOpCartRemoteDataSource()
+                }
+                val connectivity = ConnectivityObserver.observe(app)
+                return CartViewModel(app, local, remote, connectivity) as T
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/techmarketplace/presentation/product/view/ProductDetailScreen.kt
+++ b/app/src/main/java/com/techmarketplace/presentation/product/view/ProductDetailScreen.kt
@@ -2,14 +2,39 @@
 
 package com.techmarketplace.presentation.product.view
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,9 +43,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.techmarketplace.data.remote.ApiClient
-import com.techmarketplace.data.remote.dto.ListingDetailDto
 import com.techmarketplace.data.remote.api.TelemetryBatch
 import com.techmarketplace.data.remote.api.TelemetryEvent
+import com.techmarketplace.data.remote.dto.ListingDetailDto
+import com.techmarketplace.domain.cart.CartItemUpdate
+import com.techmarketplace.presentation.cart.viewmodel.CartViewModel
 import java.time.Instant
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
@@ -28,6 +55,7 @@ import retrofit2.HttpException
 @Composable
 fun ProductDetailRoute(
     listingId: String,
+    cartViewModel: CartViewModel,
     onBack: () -> Unit
 ) {
     val api = remember { ApiClient.listingApi() }
@@ -99,8 +127,36 @@ fun ProductDetailRoute(
         categoryName = categoryName,
         brandName = brandName,
         onBack = onBack,
-        onBuy = {
-            scope.launch { snack.showSnackbar("Comprar: próximamente") }
+        onAddToCart = {
+            scope.launch {
+                val current = detail
+                if (current == null) {
+                    snack.showSnackbar("Listing not loaded yet")
+                    return@launch
+                }
+                val price = current.priceCents
+                val currency = current.currency
+                val title = current.title
+                if (price == null || currency.isNullOrBlank() || title.isNullOrBlank()) {
+                    snack.showSnackbar("Listing is missing price information")
+                    return@launch
+                }
+                val update = CartItemUpdate(
+                    productId = current.id,
+                    title = title,
+                    priceCents = price,
+                    currency = currency,
+                    quantity = 1,
+                    thumbnailUrl = current.photos.firstOrNull()?.imageUrl
+                )
+                cartViewModel.addOrUpdate(update)
+                val state = cartViewModel.state.value
+                when {
+                    state.errorMessage != null -> snack.showSnackbar(state.errorMessage!!)
+                    state.isOffline -> snack.showSnackbar("Saved offline – will sync when connected")
+                    else -> snack.showSnackbar("Added to cart")
+                }
+            }
         },
         snack = snack
     )
@@ -114,7 +170,7 @@ private fun ProductDetailScreen(
     categoryName: String?,
     brandName: String?,
     onBack: () -> Unit,
-    onBuy: () -> Unit,
+    onAddToCart: () -> Unit,
     snack: SnackbarHostState
 ) {
     Scaffold(
@@ -216,12 +272,12 @@ private fun ProductDetailScreen(
 
                     Spacer(Modifier.height(12.dp))
                     Button(
-                        onClick = onBuy,
+                        onClick = onAddToCart,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(52.dp),
                         shape = RoundedCornerShape(12.dp)
-                    ) { Text("Comprar", fontSize = 16.sp, fontWeight = FontWeight.SemiBold) }
+                    ) { Text("Add to cart", fontSize = 16.sp, fontWeight = FontWeight.SemiBold) }
                     Spacer(Modifier.height(8.dp))
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ coil = "2.6.0"
 lifecycle = "2.8.6"
 material = "1.13.0"
 room = "2.6.1"
+work = "2.9.1"
 compose-ui-test = "1.7.3"
 
 # ÚNICAS versiones para Firebase y Play Services (sin duplicados)
@@ -81,3 +82,4 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose-ui-test" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui-test" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }


### PR DESCRIPTION
## Summary
- connect the Cart screen to the real CartViewModel state with quantity/update/remove actions backed by the repository
- share a single CartViewModel from MainActivity so login success and product detail screens interact with the backend cart
- allow adding listings to the cart from the product detail screen with user feedback for success, offline, or error cases

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa908ba808324a0ac953707b4203c)