### PR TITLE
Fix Room schema mismatch for cart database

### DIFF
--- a/app/src/main/java/com/techmarketplace/data/remote/api/CartApi.kt
+++ b/app/src/main/java/com/techmarketplace/data/remote/api/CartApi.kt
@@ -9,7 +9,7 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface CartApi {
-    @GET("cart")
+    @GET("cart/items")
     suspend fun getCart(): CartResponse
 
     @POST("cart/items")

--- a/app/src/main/java/com/techmarketplace/data/storage/dao/CartDatabase.kt
+++ b/app/src/main/java/com/techmarketplace/data/storage/dao/CartDatabase.kt
@@ -8,7 +8,7 @@ import androidx.room.TypeConverters
 
 @Database(
     entities = [CartItemEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(CartTypeConverters::class)


### PR DESCRIPTION
## Summary
- bump the cart Room database version so schema integrity checks succeed when opening the database
- request the cart contents from `/cart/items` so fetching the cart no longer returns a 404

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc8dd29248324a3e8922dd1543043)